### PR TITLE
Add SendTextMessageOptions for passing data to message handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,11 +111,19 @@ export interface ToolSample {
 // ============================================================================
 
 /**
+ * Options for sendTextMessage
+ */
+export interface SendTextMessageOptions {
+  /** Optional data to pass along with the message (for testing/debugging) */
+  data?: unknown;
+}
+
+/**
  * Standard props for View components
  */
 export interface ViewComponentProps<T = unknown, J = unknown> {
   selectedResult: ToolResultComplete<T, J>;
-  sendTextMessage: (text?: string) => void;
+  sendTextMessage: (text?: string, options?: SendTextMessageOptions) => void;
   onUpdateResult?: (result: Partial<ToolResult<T, J>>) => void;
   pluginConfigs?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Add `SendTextMessageOptions` interface with optional `data` field
- Extend `sendTextMessage` signature to accept options parameter
- Enables plugins to pass context data for testing/debugging

## Use case
Plugins can now pass additional context when calling `sendTextMessage`:
```typescript
props.sendTextMessage("User clicked cell", { data: { row: 3, col: 4 } });
```

This allows demo/test environments to process the data and simulate responses without requiring an LLM.

## Test plan
- [x] Build passes
- [x] Used in GUIChatPluginOthello for interactive demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)