### PR TITLE
feat: add isAudioPlaying prop to ViewComponentProps

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,10 @@ export interface ViewComponentProps<T = unknown, J = unknown> {
   sendTextMessage: (text?: string, options?: SendTextMessageOptions) => void;
   onUpdateResult?: (result: Partial<ToolResult<T, J>>) => void;
   pluginConfigs?: Record<string, unknown>;
+
+  // LLM audio playback state (for avatar lip-sync, visual feedback, etc.)
+  // true when the LLM's voice response is currently playing
+  isAudioPlaying?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `isAudioPlaying` boolean prop to `ViewComponentProps`
- Enables plugins to react to LLM audio playback state

## Use Cases
- Avatar lip-sync during voice conversations
- Visual feedback when AI is speaking
- Audio-reactive animations

## Changes
- `src/types.ts`: Added `isAudioPlaying?: boolean` to `ViewComponentProps`

🤖 Generated with [Claude Code](https://claude.ai/code)