### PR TITLE
feat: add optional action field to ToolResult (v0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/spec/GUI_CHAT_PROTOCOL.md
+++ b/spec/GUI_CHAT_PROTOCOL.md
@@ -59,7 +59,7 @@ When a tool executes, it returns a `ToolResult` with two relevant payloads:
 1. **LLM response fields** – `message` (required) and optional `jsonData` that the LLM consumes to continue the conversation
 2. **GUI payload** – `data`, a structured object tagged with a `type` identifier (e.g., `"image"`, `"map"`, `"game"`)
 
-Optional `instructions`, `title`, and `updating` fields help the LLM or UI understand how to follow up.
+Optional `instructions`, `title`, `action`, and `updating` fields help the LLM or UI understand how to follow up. `action` carries the sub-action verb the tool was invoked with (e.g. `"openApp"`, `"addEntry"`), letting hosts label multi-feature tool results in the UI without inspecting the call args.
 
 The **type** within `ToolResult.data` determines which visual component renders it:
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface ToolResult<T = unknown, J = unknown> {
   uuid?: string;
   message: string; // status message sent back to the LLM about the tool execution result
   title?: string;
+  action?: string; // sub-action / verb the tool was invoked with (e.g. "openApp", "addEntry"); used by hosts to label multi-feature tool results in the UI
   jsonData?: J; // data to be passed to the LLM
   instructions?: string; // follow-up instructions for the LLM
   instructionsRequired?: boolean; // if true, instructions will be sent even if suppressInstructions is enabled


### PR DESCRIPTION
## Summary
- Adds `action?: string` to `ToolResult` so plugins can self-describe the sub-action verb (e.g. `"openApp"`, `"addEntry"`) for multi-feature tools.
- Lets hosts label tool-result cards as `manageAccounting(openApp)` without inspecting call args (which aren't part of the result envelope and don't survive persistence on the host side).
- Purely additive — existing plugins are unaffected.
- Bumps the package to **0.2.0** (new optional schema field).

## Schema impact
\`\`\`ts
interface ToolResult<T, J> {
  // ...
  title?: string;
  action?: string; // ← new
  jsonData?: J;
  // ...
}
\`\`\`
\`ToolResultComplete\` inherits the field automatically.

## Spec
\`spec/GUI_CHAT_PROTOCOL.md\` updated to list `action` alongside the other optional fields and explain the labeling use case.

## Test plan
- [x] \`yarn typecheck\` — clean
- [x] \`yarn build\` — emits regenerated declarations
- [ ] Downstream verification: pull into a host (MulmoClaude) and confirm a plugin can populate `action` and the type narrows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)