### PR TITLE
feat: plugin runtime API (definePlugin / useRuntime / eslint-preset) — v0.3.0

### DIFF
--- a/eslint-preset.js
+++ b/eslint-preset.js
@@ -33,6 +33,15 @@ const restrictedImportPaths = [
   { name: "node:fs/promises", message: FS_MESSAGE },
   { name: "path", message: PATH_MESSAGE },
   { name: "node:path", message: PATH_MESSAGE },
+  // Subpath aliases — Node exposes the same path APIs via these, so
+  // missing them here would let plugin authors bypass the path
+  // restriction by importing from `node:path/posix` (or
+  // `path/posix`) instead. `path/win32` covers the same hole on the
+  // Windows side. Codex review #10 caught this.
+  { name: "path/posix", message: PATH_MESSAGE },
+  { name: "node:path/posix", message: PATH_MESSAGE },
+  { name: "path/win32", message: PATH_MESSAGE },
+  { name: "node:path/win32", message: PATH_MESSAGE },
 ];
 
 export default [

--- a/eslint-preset.js
+++ b/eslint-preset.js
@@ -1,0 +1,45 @@
+/**
+ * ESLint preset for gui-chat-protocol plugin authors.
+ *
+ * Plugins should write all I/O through `runtime.files.{data,config}`,
+ * all logging through `runtime.log.*`, and all paths as POSIX-relative
+ * template literals. This preset turns deviations into lint errors so
+ * platform bypasses become visible at code-review time.
+ *
+ * Usage (flat config):
+ *
+ *   // plugin/eslint.config.mjs
+ *   import pluginPreset from "gui-chat-protocol/eslint-preset";
+ *   export default [
+ *     ...pluginPreset,
+ *     // your project-specific overrides
+ *   ];
+ *
+ * Allowed Node built-ins: `node:crypto` (randomUUID etc.), `node:url`
+ * (URL parsing). `node:fs` / `node:path` are restricted because the
+ * runtime provides scoped + normalised replacements.
+ *
+ * Spec: https://github.com/receptron/mulmoclaude/issues/1110
+ */
+
+const FS_MESSAGE = "Use runtime.files.data / runtime.files.config — see https://github.com/receptron/mulmoclaude/issues/1110.";
+const PATH_MESSAGE =
+  "Plugin runtime paths are POSIX-relative; use template literals like `books/${id}.json`. The platform normalises and rejects traversal.";
+
+const restrictedImportPaths = [
+  { name: "fs", message: FS_MESSAGE },
+  { name: "node:fs", message: FS_MESSAGE },
+  { name: "fs/promises", message: FS_MESSAGE },
+  { name: "node:fs/promises", message: FS_MESSAGE },
+  { name: "path", message: PATH_MESSAGE },
+  { name: "node:path", message: PATH_MESSAGE },
+];
+
+export default [
+  {
+    rules: {
+      "no-restricted-imports": ["error", { paths: restrictedImportPaths }],
+      "no-console": ["error"],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {
@@ -18,13 +18,17 @@
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js",
       "require": "./dist/react.cjs"
+    },
+    "./eslint-preset": {
+      "default": "./eslint-preset.js"
     }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "eslint-preset.js"
   ],
   "scripts": {
     "build": "vite build",

--- a/spec/GUI_CHAT_PROTOCOL.md
+++ b/spec/GUI_CHAT_PROTOCOL.md
@@ -543,6 +543,12 @@ GUI Chat Protocol provides the foundation for this future—a future where compu
 
 **The operating system becomes a conversational partner, not a collection of apps.**
 
+## Plugin Runtime API (v0.3+)
+
+`gui-chat-protocol@0.3.0` adds an opt-in factory-shape plugin contract that gives plugins a host-constructed, per-plugin scoped runtime (`pubsub`, `files.{data,config}`, `log`, `fetch`, `notify`, `locale`, `dispatch`). See [`PLUGIN_RUNTIME.md`](./PLUGIN_RUNTIME.md) for the contract, the type surface, the path-normalisation rules, and the recommended ESLint preset.
+
+The legacy `(context, args)` shape covered in [`CREATING_A_PLUGIN.md`](./CREATING_A_PLUGIN.md) continues to work without changes. The factory shape is the recommended form for new plugins.
+
 ## Conclusion
 
 GUI Chat Protocol represents a paradigm shift from text-only to multi-modal conversational AI. By leveraging existing tool calling infrastructure and adding a visual rendering layer, it enables LLMs to produce rich, interactive experiences while remaining compatible with all major language models.

--- a/spec/PLUGIN_RUNTIME.md
+++ b/spec/PLUGIN_RUNTIME.md
@@ -14,11 +14,29 @@ import { definePlugin } from "gui-chat-protocol";
 export default definePlugin((runtime) => {
   // setup runs once at plugin load, with the per-plugin runtime
   return {
-    TOOL_DEFINITION: { /* … */ },
-    async myTool(args) { /* … */ },
+    TOOL_DEFINITION: {
+      type: "function" as const,
+      name: "myTool" as const,    // `as const` enables the strict handler-key check
+      description: "…",
+      parameters: { /* … */ },
+    },
+    async myTool(args: unknown) { /* … */ },   // explicit `: unknown` — see note below
   };
 });
 ```
+
+> **Two annotation requirements** for the strict-mode handler check
+> (`StrictPluginResult<T>`) to fire:
+>
+> 1. `TOOL_DEFINITION.name` must be a string **literal**, typically via
+>    `name: "myTool" as const`. Without `as const`, `name` widens to
+>    `string` and the check degrades to the loose runtime warn.
+> 2. The handler parameter must be **explicitly annotated** as
+>    `args: unknown`. TypeScript can't propagate contextual types into
+>    a method parameter while the surrounding generic is being
+>    inferred from the same return value (circular inference), so a
+>    bare `async myTool(args) { ... }` trips `noImplicitAny`. The
+>    handler validates `args` itself, typically via Zod.
 
 The factory:
 

--- a/spec/PLUGIN_RUNTIME.md
+++ b/spec/PLUGIN_RUNTIME.md
@@ -1,0 +1,217 @@
+# Plugin Runtime API (v0.3+)
+
+This document describes the **factory-shape plugin contract** introduced in `gui-chat-protocol@0.3.0`. It supplements [`GUI_CHAT_PROTOCOL.md`](./GUI_CHAT_PROTOCOL.md) (which covers the wire-level tool-calling protocol) and [`CREATING_A_PLUGIN.md`](./CREATING_A_PLUGIN.md) (which covers the legacy `(context, args)` plugin shape).
+
+The factory shape is **opt-in**. Existing plugins built against the legacy shape continue to work without changes — the host's runtime loader detects which shape a plugin uses and dispatches accordingly.
+
+## Contract
+
+A factory-shape plugin's `dist/index.js` exports a default factory:
+
+```ts
+import { definePlugin } from "gui-chat-protocol";
+
+export default definePlugin((runtime) => {
+  // setup runs once at plugin load, with the per-plugin runtime
+  return {
+    TOOL_DEFINITION: { /* … */ },
+    async myTool(args) { /* … */ },
+  };
+});
+```
+
+The factory:
+
+1. Receives a [`PluginRuntime`](#pluginruntime) constructed by the host, scoped to this plugin.
+2. Returns an object containing:
+   - `TOOL_DEFINITION`: the same OpenAI-shaped tool schema legacy plugins export.
+   - A handler exported under `TOOL_DEFINITION.name` (the host invokes it via `(args) =>`).
+3. Runs **once** at plugin load. Side effects are not allowed at setup time — only inside handlers.
+
+The handler signature is `(args: unknown) => unknown | Promise<unknown>`. The host validates `args` came from an LLM tool call but does not validate the shape; the plugin must do that (Zod / hand-rolled).
+
+## `PluginRuntime` (server side)
+
+```ts
+interface PluginRuntime {
+  pubsub:    { publish<T>(eventName: string, payload: T): void };
+  locale:    string;                                      // host-detected locale snapshot
+  files:     { data: FileOps; config: FileOps };          // scoped to plugin's own dir
+  log:       { debug; info; warn; error };                // (msg, data?) → void
+  fetch:     (url, opts?: PluginFetchOptions) => Promise<Response>;
+  fetchJson: <T>(url, opts: PluginFetchJsonOptions<T>) => Promise<T>;
+  fetchJson: (url, opts?: PluginFetchOptions) => Promise<unknown>;
+  notify:    (msg: PluginNotifyMessage) => void;
+}
+```
+
+### `pubsub`
+
+Scoped publisher. `publish("foo", payload)` routes to channel `plugin:<pkg>:foo`. The plugin author never spells the prefix; the host appended it at runtime construction. Cross-plugin event leakage is structurally impossible through the API.
+
+### `locale`
+
+The host-detected locale at plugin-load time (e.g. `"en"`, `"ja"`). Server-side is a **snapshot**. For reactive locale on the browser side use `BrowserPluginRuntime.locale: Ref<string>`.
+
+### `files: { data; config }`
+
+Scoped file I/O. Two separate roots, mirroring the host's own `data/` vs `config/` separation:
+
+- `files.data`: backup-target user data (e.g. the records the plugin manages on the user's behalf).
+- `files.config`: per-machine plugin settings / UI state (e.g. last-selected book id, sort preferences).
+
+Both expose the same `FileOps` shape:
+
+```ts
+interface FileOps {
+  read(rel: string): Promise<string>;
+  readBytes(rel: string): Promise<Uint8Array>;
+  write(rel: string, content: string | Uint8Array): Promise<void>;   // atomic
+  readDir(rel: string): Promise<string[]>;
+  stat(rel: string): Promise<{ mtimeMs: number; size: number }>;
+  exists(rel: string): Promise<boolean>;
+  unlink(rel: string): Promise<void>;
+}
+```
+
+### Path conventions
+
+> All `rel` arguments are **POSIX-relative paths** (`/` separated). The platform internally:
+>
+> 1. Replaces `\` with `/` (Windows `path.join` repair)
+> 2. `path.posix.normalize` to fold `..`, `.`, repeated `/`
+> 3. Resolves against the plugin's scope root
+> 4. **Rejects** anything that escapes the scope root
+>
+> Plugin authors should never need `node:path`. The recommended ESLint preset (`gui-chat-protocol/eslint-preset`) enforces this.
+
+### `fetch` / `fetchJson`
+
+Wrappers around `globalThis.fetch` with timeout (default 10s) and optional host allowlist:
+
+```ts
+runtime.fetch("https://example.com/api", {
+  timeoutMs: 5000,
+  allowedHosts: ["example.com"],
+});
+```
+
+`fetchJson` is overloaded:
+
+```ts
+fetchJson(url, opts?: PluginFetchOptions): Promise<unknown>;
+fetchJson<T>(url, opts: PluginFetchJsonOptions<T>): Promise<T>;
+```
+
+The strongly-typed overload **requires** `opts.parse` so the plugin can never get a typed value out of un-validated remote JSON. Idiomatic with Zod:
+
+```ts
+const data = await runtime.fetchJson(url, {
+  parse: (raw) => MySchema.parse(raw),
+});
+```
+
+### `log`
+
+Logger bridge to the host's central logger, prefixed with `plugin/<pkg>` automatically. Use this instead of `console.*` so plugin output lands in the central log files.
+
+### `notify`
+
+Publishes to the host's notification channel:
+
+```ts
+runtime.notify({ title: "Saved", body: "3 items", level: "info" });
+```
+
+## `BrowserPluginRuntime` (browser side)
+
+Available via `useRuntime()` from `gui-chat-protocol/vue` inside any plugin Vue component:
+
+```ts
+import { useRuntime } from "gui-chat-protocol/vue";
+
+const { pubsub, locale, openUrl, notify, dispatch, log } = useRuntime();
+```
+
+```ts
+interface BrowserPluginRuntime {
+  pubsub:  { subscribe<T>(eventName: string, handler: (payload: T) => void): () => void };
+  locale:  Ref<string>;                                  // reactive
+  log:     { debug; info; warn; error };
+  openUrl: (url: string) => void;                        // target=_blank + noopener,noreferrer
+  notify:  (msg: PluginNotifyMessage) => void;
+  dispatch<T = unknown>(args: object): Promise<T>;       // POST to this plugin's dispatch route
+}
+```
+
+`useRuntime()` **throws** when called outside a host-provided scope. Plugin Vue components should always render inside the host's plugin-scope wrapper (the host's loader is responsible for this).
+
+### `dispatch`
+
+Calls back to this plugin's server-side handler from the browser. The host attaches the bearer token + builds the URL automatically; the plugin author never spells either:
+
+```ts
+const json = await dispatch<{ ok: boolean; bookmarks: Bookmark[] }>({
+  kind: "list",
+});
+```
+
+The shape of `args` is whatever the plugin's server handler expects (typically a discriminated union by `kind` — see "Action discriminator pattern" below).
+
+## Action discriminator pattern (recommended)
+
+Use a Zod-discriminated union + exhaustive switch in the server handler:
+
+```ts
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("save"),   payload: SomeSchema }),
+  z.object({ kind: z.literal("load") }),
+]);
+
+return {
+  TOOL_DEFINITION: { /* … */ },
+  async myTool(rawArgs: unknown) {
+    const args = Args.parse(rawArgs);
+    switch (args.kind) {
+      case "save": return save(args.payload);
+      case "load": return load();
+      default: { const exhaustive: never = args; throw new Error(`unknown: ${JSON.stringify(exhaustive)}`); }
+    }
+  },
+};
+```
+
+The `default: never` clause is the safety net — adding a new `kind` to `Args` later but forgetting a `case` becomes a build-time TypeScript error rather than a silent runtime drop-through.
+
+## ESLint preset
+
+Plugin authors should extend `gui-chat-protocol/eslint-preset`:
+
+```js
+// plugin/eslint.config.mjs
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+export default [...pluginPreset];
+```
+
+The preset turns these into errors:
+
+| Rule | Why |
+|---|---|
+| `no-restricted-imports` for `fs` / `node:fs` / `fs/promises` / `node:fs/promises` | Use `runtime.files.data` / `runtime.files.config` |
+| `no-restricted-imports` for `path` / `node:path` / `node:path/posix` / `node:path/win32` | Use POSIX template literals — paths are platform-normalised |
+| `no-console` | Use `runtime.log.*` so output lands in the central log files |
+
+Allowed: `node:crypto` (`randomUUID` etc.), `node:url` (URL parsing). When an `import` matching the restricted list shows up in plugin source, that's the audit signal — the plugin is reaching around the platform.
+
+## Backward compatibility
+
+Plugins built against the legacy `(context, args)` shape continue to work. The host's runtime loader detects which shape a plugin uses (`typeof mod.default === "function"` → factory; otherwise legacy raw exports). Existing `@gui-chat-plugin/*` packages need no changes.
+
+The factory shape is the **recommended** form for new plugins.
+
+## See also
+
+- [`GUI_CHAT_PROTOCOL.md`](./GUI_CHAT_PROTOCOL.md) — wire-level tool-calling protocol
+- [`CREATING_A_PLUGIN.md`](./CREATING_A_PLUGIN.md) — legacy plugin shape walkthrough
+- [`API_REFERENCE.md`](./API_REFERENCE.md) — full API reference
+- [receptron/mulmoclaude#1110](https://github.com/receptron/mulmoclaude/issues/1110) — host-side spec, motivation, threat model, migration plan

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@
 export * from "./types";
 export * from "./inputHandlers";
 export * from "./schema";
+export * from "./runtime";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -157,33 +157,35 @@ export interface PluginRuntime {
 // ============================================================================
 
 /**
- * What a plugin's `setup` function returns. `TOOL_DEFINITION` is required;
- * a handler must be exported under the same key as `TOOL_DEFINITION.name`
- * (the convention the runtime loader resolves at call time).
+ * What a plugin's `setup` function returns at the **loose** level —
+ * just `TOOL_DEFINITION`. Whether a matching named handler is
+ * type-required is decided by the wrapper type `StrictPluginResult`
+ * (used by `definePlugin` below) rather than by this base shape, so
+ * the runtime loader's `isPluginFactory` predicate can keep using
+ * the loose form when it doesn't yet know the tool name.
  *
- * The conditional `string extends N` branch handles two cases:
- *   - **Strict** (preferred): `TOOL_DEFINITION.name` is a string literal
- *     (e.g. via `name: "myTool" as const`). `N` infers as the literal,
- *     `string extends N` is false, and the mapped-type member
- *     `{ [K in N]: handler }` makes the handler type-required at the
- *     `definePlugin` call site. Forgetting to export a function under
- *     the matching name becomes a TypeScript error.
- *   - **Loose**: `TOOL_DEFINITION.name` widens to `string` (no `as
- *     const` on the name). `string extends N` is true, the mapped
- *     member would otherwise demand every string key be a function,
- *     so we fall back to the looser `[exportName: string]: unknown`
- *     shape. The runtime loader's existing handler-presence warn at
- *     load time is the safety net here.
- *
- * Codex review #10 (item 1) caught the original always-loose shape;
- * this conditional restores type safety for the strict path without
- * breaking authors who haven't adopted `as const` yet.
+ * Codex review #10 caught two iterations of looser-than-intended
+ * checks here; the final form below uses an inference helper so the
+ * strict requirement actually fires at the `definePlugin` call site.
  */
-export type PluginFactoryResult<N extends string = string> = {
-  TOOL_DEFINITION: ToolDefinition & { name: N };
-} & (string extends N
-  ? { [exportName: string]: unknown }
-  : { [K in N]: (args: never) => unknown | Promise<unknown> });
+export interface PluginFactoryResult {
+  TOOL_DEFINITION: ToolDefinition;
+  [exportName: string]: unknown;
+}
+
+/**
+ * Compile-time strict shape used to constrain `definePlugin`'s setup
+ * return type. Extracts the `name` literal out of `T.TOOL_DEFINITION`
+ * and demands a handler key matching it. When `name` widens to
+ * `string` (no `as const`), the strict check degrades to the loose
+ * `PluginFactoryResult` and the runtime loader's load-time warn is
+ * the safety net.
+ */
+export type StrictPluginResult<T> = T extends { TOOL_DEFINITION: { name: infer N extends string } }
+  ? string extends N
+    ? PluginFactoryResult
+    : T & { [K in N]: (args: never) => unknown | Promise<unknown> }
+  : never;
 
 /**
  * Identity function for type inference. Same philosophy as
@@ -191,18 +193,20 @@ export type PluginFactoryResult<N extends string = string> = {
  * TypeScript thread the runtime/result types so the plugin author
  * gets full IntelliSense on `runtime.X` without manual annotations.
  *
- * The `N` generic is inferred from `TOOL_DEFINITION.name`. To make
- * this work the plugin author should declare the name as a
- * literal, typically by `as const`:
+ * Generic placement (T inferred from setup's return) lets
+ * `StrictPluginResult<T>` extract `TOOL_DEFINITION.name` and require
+ * a matching named handler — Codex review #10 iter-2 caught that an
+ * earlier `<N extends string, T extends PluginFactoryResult<N>>`
+ * shape would not actually narrow `N` at the call site.
  *
- *   TOOL_DEFINITION: { type: "function" as const, name: "myTool", ... }
+ * Plugin authors should declare `name` as a literal (`as const`) so
+ * the strict handler check fires:
  *
- * Without `as const` the inferred name widens to `string`, which still
- * type-checks but loses the handler-key requirement (the mapped-type
- * member becomes `[K in string]` which is satisfied by any plain
- * record). The runtime loader still warns at load time, so this is a
- * graceful degradation — but plugin authors should prefer the
- * literal-narrowing form for the strict check.
+ *   TOOL_DEFINITION: { type: "function" as const, name: "myTool" as const, ... }
+ *
+ * Without `as const`, `N` widens to `string` and the strict check
+ * gracefully degrades to the loose runtime warn (see
+ * `StrictPluginResult` above).
  *
  * @example
  * ```ts
@@ -221,8 +225,8 @@ export type PluginFactoryResult<N extends string = string> = {
  * }));
  * ```
  */
-export function definePlugin<N extends string, T extends PluginFactoryResult<N>>(
-  setup: (runtime: PluginRuntime) => T,
+export function definePlugin<T extends PluginFactoryResult>(
+  setup: (runtime: PluginRuntime) => T & StrictPluginResult<T>,
 ): (runtime: PluginRuntime) => T {
   return setup;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -63,11 +63,15 @@ export interface PluginFetchOptions extends PluginFetchInit {
 
 export interface PluginFetchJsonOptions<T> extends PluginFetchOptions {
   /**
-   * Optional Zod-agnostic validator. Pass a function that returns the
-   * narrowed value (or throws). Idiomatic with Zod:
-   * `parse: (raw) => MySchema.parse(raw)`.
+   * Zod-agnostic validator. Pass a function that returns the narrowed
+   * value (or throws). Idiomatic with Zod:
+   *   `parse: (raw) => MySchema.parse(raw)`.
+   *
+   * Required when calling `fetchJson<T>` for any T other than
+   * `unknown` — the overload signatures below enforce this so callers
+   * never get a strongly-typed value out of unvalidated JSON.
    */
-  parse?: (raw: unknown) => T;
+  parse: (raw: unknown) => T;
 }
 
 export interface PluginNotifyMessage {
@@ -130,8 +134,19 @@ export interface PluginRuntime {
    */
   fetch(url: string, opts?: PluginFetchOptions): Promise<Response>;
 
-  /** `fetch` + `response.json()` + optional Zod-agnostic validator. */
-  fetchJson<T>(url: string, opts?: PluginFetchJsonOptions<T>): Promise<T>;
+  /**
+   * `fetch` + `response.json()` + optional validator.
+   *
+   * - Without `opts.parse`, the result type is `unknown` — callers
+   *   must narrow before use. This prevents strongly-typed access to
+   *   un-validated remote JSON, which is a frequent type-soundness
+   *   bug ("the server promised X, then it didn't").
+   * - With `opts.parse`, the validator's return type narrows the
+   *   promise. Idiomatic with Zod:
+   *   `await fetchJson(url, { parse: (raw) => MySchema.parse(raw) })`.
+   */
+  fetchJson(url: string, opts?: PluginFetchOptions): Promise<unknown>;
+  fetchJson<T>(url: string, opts: PluginFetchJsonOptions<T>): Promise<T>;
 
   /** Publish a notification through the host's notifications channel. */
   notify(msg: PluginNotifyMessage): void;
@@ -143,15 +158,32 @@ export interface PluginRuntime {
 
 /**
  * What a plugin's `setup` function returns. `TOOL_DEFINITION` is required;
- * the handler is exported under the same key as `TOOL_DEFINITION.name`
+ * a handler must be exported under the same key as `TOOL_DEFINITION.name`
  * (the convention the runtime loader resolves at call time).
+ *
+ * The conditional `string extends N` branch handles two cases:
+ *   - **Strict** (preferred): `TOOL_DEFINITION.name` is a string literal
+ *     (e.g. via `name: "myTool" as const`). `N` infers as the literal,
+ *     `string extends N` is false, and the mapped-type member
+ *     `{ [K in N]: handler }` makes the handler type-required at the
+ *     `definePlugin` call site. Forgetting to export a function under
+ *     the matching name becomes a TypeScript error.
+ *   - **Loose**: `TOOL_DEFINITION.name` widens to `string` (no `as
+ *     const` on the name). `string extends N` is true, the mapped
+ *     member would otherwise demand every string key be a function,
+ *     so we fall back to the looser `[exportName: string]: unknown`
+ *     shape. The runtime loader's existing handler-presence warn at
+ *     load time is the safety net here.
+ *
+ * Codex review #10 (item 1) caught the original always-loose shape;
+ * this conditional restores type safety for the strict path without
+ * breaking authors who haven't adopted `as const` yet.
  */
-export interface PluginFactoryResult {
-  TOOL_DEFINITION: ToolDefinition;
-  // Handler under TOOL_DEFINITION.name is required; other keys may be
-  // exported but the loader only invokes the named one.
-  [exportName: string]: unknown;
-}
+export type PluginFactoryResult<N extends string = string> = {
+  TOOL_DEFINITION: ToolDefinition & { name: N };
+} & (string extends N
+  ? { [exportName: string]: unknown }
+  : { [K in N]: (args: never) => unknown | Promise<unknown> });
 
 /**
  * Identity function for type inference. Same philosophy as
@@ -159,10 +191,28 @@ export interface PluginFactoryResult {
  * TypeScript thread the runtime/result types so the plugin author
  * gets full IntelliSense on `runtime.X` without manual annotations.
  *
+ * The `N` generic is inferred from `TOOL_DEFINITION.name`. To make
+ * this work the plugin author should declare the name as a
+ * literal, typically by `as const`:
+ *
+ *   TOOL_DEFINITION: { type: "function" as const, name: "myTool", ... }
+ *
+ * Without `as const` the inferred name widens to `string`, which still
+ * type-checks but loses the handler-key requirement (the mapped-type
+ * member becomes `[K in string]` which is satisfied by any plain
+ * record). The runtime loader still warns at load time, so this is a
+ * graceful degradation — but plugin authors should prefer the
+ * literal-narrowing form for the strict check.
+ *
  * @example
  * ```ts
  * export default definePlugin(({ pubsub, files, locale }) => ({
- *   TOOL_DEFINITION: { name: "myTool", description: "...", parameters: { ... } },
+ *   TOOL_DEFINITION: {
+ *     type: "function" as const,
+ *     name: "myTool" as const,
+ *     description: "...",
+ *     parameters: { type: "object", properties: {}, required: [] },
+ *   },
  *   async myTool(args) {
  *     await files.data.write("state.json", JSON.stringify(args));
  *     pubsub.publish("changed", {});
@@ -171,14 +221,19 @@ export interface PluginFactoryResult {
  * }));
  * ```
  */
-export function definePlugin<T extends PluginFactoryResult>(
+export function definePlugin<N extends string, T extends PluginFactoryResult<N>>(
   setup: (runtime: PluginRuntime) => T,
 ): (runtime: PluginRuntime) => T {
   return setup;
 }
 
 /** Type guard the runtime loader uses to detect factory-shape vs. legacy
- *  raw-export plugins. Exported so other host code can share the test. */
+ *  raw-export plugins. Exported so other host code can share the test.
+ *  Loosened to the widened `PluginFactoryResult<string>` because the
+ *  caller (the runtime loader) doesn't know the plugin's tool name at
+ *  this point — it pulls `TOOL_DEFINITION` from the factory's return
+ *  value to discover it. The strict, name-narrowed form is enforced at
+ *  the `definePlugin` call site instead. */
 export function isPluginFactory(value: unknown): value is (runtime: PluginRuntime) => PluginFactoryResult {
   return typeof value === "function";
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,184 @@
+/**
+ * Plugin runtime — the platform-provided helpers a plugin author receives
+ * via the `definePlugin` factory. Framework-agnostic core; Vue-specific
+ * `BrowserPluginRuntime` lives in `./vue.ts`.
+ *
+ * Spec: https://github.com/receptron/mulmoclaude/issues/1110
+ */
+
+import type { ToolDefinition } from "./types";
+
+// ============================================================================
+// File I/O — scoped to plugin's data or config root
+// ============================================================================
+
+/**
+ * File operations scoped to a single root directory (data or config).
+ * All `rel` arguments are POSIX-relative paths. The platform normalises
+ * input (`\` → `/`, `path.posix.normalize`, `ensureInsideBase`) before
+ * touching disk, so misuse of `node:path` on Windows still works and
+ * `"../../etc/passwd"` is rejected.
+ *
+ * Plugin authors should never need `node:fs` or `node:path`.
+ */
+export interface FileOps {
+  /** Read UTF-8 string. Throws if the file does not exist. */
+  read(rel: string): Promise<string>;
+  /** Read raw bytes. */
+  readBytes(rel: string): Promise<Uint8Array>;
+  /** Write atomically. Creates parent directories as needed. */
+  write(rel: string, content: string | Uint8Array): Promise<void>;
+  /** List basenames in `rel`. */
+  readDir(rel: string): Promise<string[]>;
+  /** mtime (ms since epoch) and byte size. */
+  stat(rel: string): Promise<{ mtimeMs: number; size: number }>;
+  /** Existence check (saves try/catch boilerplate). */
+  exists(rel: string): Promise<boolean>;
+  /** Delete a file. No-op if it does not exist. */
+  unlink(rel: string): Promise<void>;
+}
+
+// ============================================================================
+// Server-side runtime
+// ============================================================================
+
+/**
+ * Subset of `RequestInit` the runtime forwards to the underlying fetch.
+ * Re-declared here so we don't need a `lib.dom` dependency in the core
+ * type declaration.
+ */
+export interface PluginFetchInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Uint8Array;
+  signal?: AbortSignal;
+}
+
+export interface PluginFetchOptions extends PluginFetchInit {
+  /** AbortController timeout. Default 10 000 ms. */
+  timeoutMs?: number;
+  /** When set, requests to a `URL.hostname` not in the list throw. */
+  allowedHosts?: readonly string[];
+}
+
+export interface PluginFetchJsonOptions<T> extends PluginFetchOptions {
+  /**
+   * Optional Zod-agnostic validator. Pass a function that returns the
+   * narrowed value (or throws). Idiomatic with Zod:
+   * `parse: (raw) => MySchema.parse(raw)`.
+   */
+  parse?: (raw: unknown) => T;
+}
+
+export interface PluginNotifyMessage {
+  title: string;
+  body?: string;
+  level?: "info" | "warn" | "error";
+}
+
+/**
+ * Runtime handed to a plugin's `definePlugin(setup)` factory at load time.
+ * The plugin closes over the destructured fields; handlers reference them
+ * as bare API calls (no `context.` indirection).
+ *
+ * `pubsub` / `files.*` / `log` are scoped per plugin. The plugin cannot
+ * spell another plugin's channel or file path through the API.
+ */
+export interface PluginRuntime {
+  /**
+   * Scoped pub/sub publisher. `publish("foo", payload)` is internally
+   * routed to channel `plugin:<pkg>:foo`. The plugin cannot publish to
+   * another plugin's namespace.
+   */
+  pubsub: {
+    publish<T>(eventName: string, payload: T): void;
+  };
+
+  /**
+   * Locale tag the host detected at startup (`"en"`, `"ja"`, …). The
+   * server side is a snapshot; for reactive updates use the frontend
+   * `BrowserPluginRuntime.locale: Ref<string>` instead.
+   */
+  locale: string;
+
+  /**
+   * Scoped file I/O.
+   *   - `data`:   `~/mulmoclaude/data/plugins/<pkg>/`   — backup target
+   *   - `config`: `~/mulmoclaude/config/plugins/<pkg>/` — per-machine UI state
+   */
+  files: {
+    data: FileOps;
+    config: FileOps;
+  };
+
+  /**
+   * Logger bridge to the host's logger. Prefix `plugin/<pkg>` is added
+   * automatically. Use this instead of `console.*` so plugin output
+   * lands in the central log files.
+   */
+  log: {
+    debug(msg: string, data?: object): void;
+    info(msg: string, data?: object): void;
+    warn(msg: string, data?: object): void;
+    error(msg: string, data?: object): void;
+  };
+
+  /**
+   * `fetch` wrapper with timeout and (optional) host allowlist. Use
+   * instead of `globalThis.fetch` so timeouts and allowlists are
+   * applied uniformly across all plugins.
+   */
+  fetch(url: string, opts?: PluginFetchOptions): Promise<Response>;
+
+  /** `fetch` + `response.json()` + optional Zod-agnostic validator. */
+  fetchJson<T>(url: string, opts?: PluginFetchJsonOptions<T>): Promise<T>;
+
+  /** Publish a notification through the host's notifications channel. */
+  notify(msg: PluginNotifyMessage): void;
+}
+
+// ============================================================================
+// Plugin factory
+// ============================================================================
+
+/**
+ * What a plugin's `setup` function returns. `TOOL_DEFINITION` is required;
+ * the handler is exported under the same key as `TOOL_DEFINITION.name`
+ * (the convention the runtime loader resolves at call time).
+ */
+export interface PluginFactoryResult {
+  TOOL_DEFINITION: ToolDefinition;
+  // Handler under TOOL_DEFINITION.name is required; other keys may be
+  // exported but the loader only invokes the named one.
+  [exportName: string]: unknown;
+}
+
+/**
+ * Identity function for type inference. Same philosophy as
+ * `defineComponent` in Vue: it does nothing at runtime, just lets
+ * TypeScript thread the runtime/result types so the plugin author
+ * gets full IntelliSense on `runtime.X` without manual annotations.
+ *
+ * @example
+ * ```ts
+ * export default definePlugin(({ pubsub, files, locale }) => ({
+ *   TOOL_DEFINITION: { name: "myTool", description: "...", parameters: { ... } },
+ *   async myTool(args) {
+ *     await files.data.write("state.json", JSON.stringify(args));
+ *     pubsub.publish("changed", {});
+ *     return { ok: true };
+ *   },
+ * }));
+ * ```
+ */
+export function definePlugin<T extends PluginFactoryResult>(
+  setup: (runtime: PluginRuntime) => T,
+): (runtime: PluginRuntime) => T {
+  return setup;
+}
+
+/** Type guard the runtime loader uses to detect factory-shape vs. legacy
+ *  raw-export plugins. Exported so other host code can share the test. */
+export function isPluginFactory(value: unknown): value is (runtime: PluginRuntime) => PluginFactoryResult {
+  return typeof value === "function";
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -184,8 +184,18 @@ export interface PluginFactoryResult {
 export type StrictPluginResult<T> = T extends { TOOL_DEFINITION: { name: infer N extends string } }
   ? string extends N
     ? PluginFactoryResult
-    : T & { [K in N]: (args: never) => unknown | Promise<unknown> }
+    : T & { [K in N]: (args: unknown) => unknown | Promise<unknown> }
   : never;
+// `(args: unknown)` not `(args: never)`: the parameter type is the
+// **contextual** type a plugin author sees when writing
+// `async myTool(args) { ... }` without an explicit annotation. With
+// `never` the plugin's `args` would infer as `never` and any access
+// would fail TS7006 / TS2339; with `unknown` it infers as `unknown`
+// (matching the dispatch route's actual contract — the plugin
+// validates args itself, typically via Zod). Function parameter
+// contravariance still lets the constraint accept any concrete
+// `(args: T) => ...` shape from the author. Codex review #10 iter-3
+// caught the `never` regression.
 
 /**
  * Identity function for type inference. Same philosophy as
@@ -208,6 +218,14 @@ export type StrictPluginResult<T> = T extends { TOOL_DEFINITION: { name: infer N
  * gracefully degrades to the loose runtime warn (see
  * `StrictPluginResult` above).
  *
+ * **Annotate the handler parameter explicitly** as `args: unknown`.
+ * TypeScript can't propagate the contextual type into the method
+ * parameter when it's still inferring `T` from the same return value
+ * (circular), so leaving `args` un-annotated trips `noImplicitAny`.
+ * Always:
+ *
+ *   async myTool(args: unknown) { ... }
+ *
  * @example
  * ```ts
  * export default definePlugin(({ pubsub, files, locale }) => ({
@@ -217,7 +235,8 @@ export type StrictPluginResult<T> = T extends { TOOL_DEFINITION: { name: infer N
  *     description: "...",
  *     parameters: { type: "object", properties: {}, required: [] },
  *   },
- *   async myTool(args) {
+ *   async myTool(args: unknown) {
+ *     // narrow `args` here — typically with Zod
  *     await files.data.write("state.json", JSON.stringify(args));
  *     pubsub.publish("changed", {});
  *     return { ok: true };

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -5,11 +5,89 @@
  * Use these types when building Vue-based plugin UI components.
  */
 
-import type { Component } from "vue";
+import { inject, type Component, type InjectionKey, type Ref } from "vue";
 import type { ToolPluginCore, InputHandler } from "./index";
+import type { PluginNotifyMessage } from "./runtime";
 
 // Re-export all core types
 export * from "./index";
+
+// ============================================================================
+// Browser-side plugin runtime
+// ============================================================================
+
+/**
+ * Runtime exposed to a plugin's Vue components via `useRuntime()`. The
+ * host wraps a plugin's component subtree in a scope provider that
+ * `provide`s a per-plugin instance to `PLUGIN_RUNTIME_KEY`.
+ *
+ * Spec: https://github.com/receptron/mulmoclaude/issues/1110
+ */
+export interface BrowserPluginRuntime {
+  /**
+   * Scoped pub/sub client. `subscribe("foo", handler)` is internally
+   * routed to channel `plugin:<pkg>:foo`. Returns an unsubscribe
+   * function.
+   */
+  pubsub: {
+    subscribe<T>(eventName: string, handler: (payload: T) => void): () => void;
+  };
+
+  /**
+   * Reactive locale ref. When the host implements a locale picker, the
+   * plugin's UI re-renders automatically.
+   */
+  locale: Ref<string>;
+
+  /** Same shape as the server-side logger. */
+  log: {
+    debug(msg: string, data?: object): void;
+    info(msg: string, data?: object): void;
+    warn(msg: string, data?: object): void;
+    error(msg: string, data?: object): void;
+  };
+
+  /**
+   * Open `url` in a new tab with `noopener,noreferrer`. Use instead of
+   * `<a target="_blank">` so the security flags can't be forgotten at
+   * call sites.
+   */
+  openUrl(url: string): void;
+
+  /** Show a host-managed toast / notification. */
+  notify(msg: PluginNotifyMessage): void;
+
+  /**
+   * POST `args` to this plugin's server-side dispatch route
+   * (`/api/plugins/runtime/<pkg>/dispatch`) and return the parsed
+   * JSON response. The host attaches the bearer token + builds the
+   * URL automatically; the plugin author doesn't need to know either.
+   * Throws on network error or non-2xx response.
+   */
+  dispatch<T = unknown>(args: object): Promise<T>;
+}
+
+/**
+ * Vue injection key for `BrowserPluginRuntime`. The host's runtime
+ * plugin loader provides a per-plugin instance here; `useRuntime()`
+ * inside a plugin component picks it up.
+ */
+export const PLUGIN_RUNTIME_KEY: InjectionKey<BrowserPluginRuntime> = Symbol("guiChatPluginRuntime");
+
+/**
+ * Composable that returns the plugin's `BrowserPluginRuntime`. Throws
+ * a descriptive error if called outside the host's scope provider so
+ * misuse fails loudly during development.
+ */
+export function useRuntime(): BrowserPluginRuntime {
+  const runtime = inject(PLUGIN_RUNTIME_KEY);
+  if (!runtime) {
+    throw new Error(
+      "useRuntime() called outside of <PluginScopedRoot> — the host must provide PLUGIN_RUNTIME_KEY",
+    );
+  }
+  return runtime;
+}
 
 // ============================================================================
 // Vue-specific Types


### PR DESCRIPTION
## Summary

Tracks [receptron/mulmoclaude#1110](https://github.com/receptron/mulmoclaude/issues/1110). Adds the platform surface that lets a host (MulmoClaude today, future hosts later) hand a runtime-loaded plugin a per-plugin scoped runtime so plugin authors get `pubsub` / `files` / `log` / `fetch` / `notify` / `locale` / `dispatch` as bare API calls — no `context.X` boilerplate, no URL-or-token plumbing for HTTP dispatch, no `node:fs` access at all.

This is **backward compatible** — existing `@gui-chat-plugin/*` packages built against v0.2 (legacy `(context, args)` shape, raw module exports) keep working with no changes.

## Items to Confirm / Review

- **Factory pattern over context-passing**: `definePlugin(setup => ({...}))` so the host can construct a per-plugin runtime that the handler closes over. Plugin author writes `pubsub.publish("changed")` from inside any handler without ever spelling the namespace prefix; the runtime appended `plugin:<pkg>:` at construction. Cross-plugin event leakage is structurally impossible through the API. The alternative — `(context, args) => ...` — would require plugin authors to thread `context.pubsub.publish(...)` everywhere AND would let them spell other plugins' channels by accident.
- **No `import { runtime } from "gui-chat-protocol"` shape**: tempting, but Node's ESM module cache singletons the package across plugins; the second plugin's `setup({name: "..."})` would clobber the first's. The factory pattern's closure capture is per-plugin by construction. Worth confirming this trade-off matches your taste.
- **`useRuntime()` throws when called outside `<PluginScopedRoot>`**: chosen instead of returning a default runtime so misuse fails loudly during development. The host's loader is responsible for wrapping plugin component subtrees in `<PluginScopedRoot>` (see the host PR).
- **`PLUGIN_RUNTIME_KEY` is a Symbol** — host and plugin must share one module instance for the inject to connect. Hosts implement this via importmap (browser) and Node ESM resolution (server). Worth confirming the importmap pattern documented in the host repo's plan file.
- **`dispatch<T>(args)` exists on the browser runtime, but not on the server runtime**: server-side handlers are the dispatch target, not callers. Asymmetric on purpose. Confirm.
- **ESLint preset is a flat-config-only export**: `gui-chat-protocol/eslint-preset`. Bans `node:fs` / `node:path` / `console` only — all I/O has runtime equivalents. `node:crypto` / `node:url` left alone (utility, no I/O).
- **Backward compat detection** (`isPluginFactory`): `typeof mod.default === "function"`. If a future plugin author exports a non-factory function as default, it would be misclassified. Acceptable trade-off — the convention is clear and the rest of the loader's `TOOL_DEFINITION` check is the safety net.

## Implementation

### Server side (`src/runtime.ts`, `src/index.ts`)

```ts
export interface PluginRuntime {
  pubsub: { publish<T>(eventName: string, payload: T): void };
  locale: string;
  files:  { data: FileOps; config: FileOps };
  log:    { debug; info; warn; error };
  fetch:  (url, opts?) => Promise<Response>;
  fetchJson: <T>(url, opts?) => Promise<T>;
  notify: (msg) => void;
}

export interface FileOps {
  read(rel): Promise<string>;
  readBytes(rel): Promise<Uint8Array>;
  write(rel, content): Promise<void>;
  readDir(rel): Promise<string[]>;
  stat(rel): Promise<{ mtimeMs; size }>;
  exists(rel): Promise<boolean>;
  unlink(rel): Promise<void>;
}

export function definePlugin<T extends PluginFactoryResult>(
  setup: (runtime: PluginRuntime) => T,
): (runtime: PluginRuntime) => T {
  return setup;  // identity — type inference only
}

export function isPluginFactory(value: unknown): value is (runtime: PluginRuntime) => PluginFactoryResult;
```

### Browser side (`src/vue.ts`)

```ts
export interface BrowserPluginRuntime {
  pubsub:  { subscribe<T>(eventName, handler): () => void };
  locale:  Ref<string>;
  log:     { debug; info; warn; error };
  openUrl: (url: string) => void;
  notify:  (msg) => void;
  dispatch<T = unknown>(args: object): Promise<T>;
}

export const PLUGIN_RUNTIME_KEY: InjectionKey<BrowserPluginRuntime>;
export function useRuntime(): BrowserPluginRuntime;  // throws outside <PluginScopedRoot>
```

### ESLint preset (`eslint-preset.js`)

Flat-config preset that turns `no-restricted-imports` (fs/path) + `no-console` into errors. Plugin authors extend via `gui-chat-protocol/eslint-preset`. `node:crypto` / `node:url` allowed.

## Smoke confirmation

End-to-end verified manually via a workspace reference plugin (`@mulmoclaude/bookmarks-plugin`, lives in receptron/mulmoclaude as a workspace package — not yet published):

- Factory called once at load with the per-plugin runtime
- Handler captures runtime in closure
- `pubsub.publish("changed")` routes to `plugin:@mulmoclaude/bookmarks-plugin:changed`
- Plugin Vue component picks up runtime via `useRuntime()` from inside `<PluginScopedRoot>`
- `dispatch({kind:"list"})` POSTs to dispatch route with bearer token attached
- Multi-tab live sync via subscribe → refetch
- Plugin source contains 0 references to `node:fs` / `node:path` / `console` / direct `fetch` (grep clean, ESLint-enforced)

## Test plan

- [ ] `yarn typecheck` clean
- [ ] `yarn build` clean — `dist/runtime.{js,cjs,d.ts}`, updated `dist/index.{js,cjs,d.ts}`, updated `dist/vue.{js,cjs,d.ts}`, `eslint-preset.js` shipped
- [ ] Existing weather plugin (legacy `(context, args)` shape) imports still type-check against the new package version

## Out of scope for this PR

- Per-plugin permission model / process isolation — separate issue
- KV / scheduler / callPlugin runtime APIs — see #1110 for the rationale
- Bookmarks reference plugin extraction to its own repo — follow-up after the host PR lands

## Related

- receptron/mulmoclaude#1110 — full spec for the host-side platform extensions
- receptron/mulmoclaude#1077 — runtime plugin install system this builds on
- receptron/mulmoclaude#1043 — plugin SDK / dynamic install / marketplace umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)