### PR TITLE
refactor: remove notify from PluginRuntime / BrowserPluginRuntime

### DIFF
--- a/spec/GUI_CHAT_PROTOCOL.md
+++ b/spec/GUI_CHAT_PROTOCOL.md
@@ -545,7 +545,7 @@ GUI Chat Protocol provides the foundation for this future—a future where compu
 
 ## Plugin Runtime API (v0.3+)
 
-`gui-chat-protocol@0.3.0` adds an opt-in factory-shape plugin contract that gives plugins a host-constructed, per-plugin scoped runtime (`pubsub`, `files.{data,config}`, `log`, `fetch`, `notify`, `locale`, `dispatch`). See [`PLUGIN_RUNTIME.md`](./PLUGIN_RUNTIME.md) for the contract, the type surface, the path-normalisation rules, and the recommended ESLint preset.
+`gui-chat-protocol@0.3.0` adds an opt-in factory-shape plugin contract that gives plugins a host-constructed, per-plugin scoped runtime (`pubsub`, `files.{data,config}`, `log`, `fetch`, `locale`, `dispatch`). See [`PLUGIN_RUNTIME.md`](./PLUGIN_RUNTIME.md) for the contract, the type surface, the path-normalisation rules, and the recommended ESLint preset.
 
 The legacy `(context, args)` shape covered in [`CREATING_A_PLUGIN.md`](./CREATING_A_PLUGIN.md) continues to work without changes. The factory shape is the recommended form for new plugins.
 

--- a/spec/PLUGIN_RUNTIME.md
+++ b/spec/PLUGIN_RUNTIME.md
@@ -59,7 +59,6 @@ interface PluginRuntime {
   fetch:     (url, opts?: PluginFetchOptions) => Promise<Response>;
   fetchJson: <T>(url, opts: PluginFetchJsonOptions<T>) => Promise<T>;
   fetchJson: (url, opts?: PluginFetchOptions) => Promise<unknown>;
-  notify:    (msg: PluginNotifyMessage) => void;
 }
 ```
 
@@ -133,14 +132,6 @@ const data = await runtime.fetchJson(url, {
 
 Logger bridge to the host's central logger, prefixed with `plugin/<pkg>` automatically. Use this instead of `console.*` so plugin output lands in the central log files.
 
-### `notify`
-
-Publishes to the host's notification channel:
-
-```ts
-runtime.notify({ title: "Saved", body: "3 items", level: "info" });
-```
-
 ## `BrowserPluginRuntime` (browser side)
 
 Available via `useRuntime()` from `gui-chat-protocol/vue` inside any plugin Vue component:
@@ -148,7 +139,7 @@ Available via `useRuntime()` from `gui-chat-protocol/vue` inside any plugin Vue 
 ```ts
 import { useRuntime } from "gui-chat-protocol/vue";
 
-const { pubsub, locale, openUrl, notify, dispatch, log } = useRuntime();
+const { pubsub, locale, openUrl, dispatch, log } = useRuntime();
 ```
 
 ```ts
@@ -157,7 +148,6 @@ interface BrowserPluginRuntime {
   locale:  Ref<string>;                                  // reactive
   log:     { debug; info; warn; error };
   openUrl: (url: string) => void;                        // target=_blank + noopener,noreferrer
-  notify:  (msg: PluginNotifyMessage) => void;
   dispatch<T = unknown>(args: object): Promise<T>;       // POST to this plugin's dispatch route
 }
 ```

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -74,12 +74,6 @@ export interface PluginFetchJsonOptions<T> extends PluginFetchOptions {
   parse: (raw: unknown) => T;
 }
 
-export interface PluginNotifyMessage {
-  title: string;
-  body?: string;
-  level?: "info" | "warn" | "error";
-}
-
 /**
  * Runtime handed to a plugin's `definePlugin(setup)` factory at load time.
  * The plugin closes over the destructured fields; handlers reference them
@@ -147,9 +141,6 @@ export interface PluginRuntime {
    */
   fetchJson(url: string, opts?: PluginFetchOptions): Promise<unknown>;
   fetchJson<T>(url: string, opts: PluginFetchJsonOptions<T>): Promise<T>;
-
-  /** Publish a notification through the host's notifications channel. */
-  notify(msg: PluginNotifyMessage): void;
 }
 
 // ============================================================================

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -7,7 +7,6 @@
 
 import { inject, type Component, type InjectionKey, type Ref } from "vue";
 import type { ToolPluginCore, InputHandler } from "./index";
-import type { PluginNotifyMessage } from "./runtime";
 
 // Re-export all core types
 export * from "./index";
@@ -53,9 +52,6 @@ export interface BrowserPluginRuntime {
    * call sites.
    */
   openUrl(url: string): void;
-
-  /** Show a host-managed toast / notification. */
-  notify(msg: PluginNotifyMessage): void;
 
   /**
    * POST `args` to this plugin's server-side dispatch route


### PR DESCRIPTION
## Summary
- Drop \`notify\` field from \`PluginRuntime\` (server) and \`BrowserPluginRuntime\` (browser)
- Drop the \`PluginNotifyMessage\` type
- Update \`spec/PLUGIN_RUNTIME.md\` and \`spec/GUI_CHAT_PROTOCOL.md\` accordingly

## Why
No plugin actually calls \`runtime.notify(...)\`. Removing dead surface area before more downstream consumers ship against it.

## Items to Confirm / Review
- Version bump intentionally **not** done — keep at \`0.3.0\` for now
- mulmoclaude3 / mulmoclaude5 implement \`notify\` on the host side (no callers); will be cleaned up separately
- \`yarn typecheck\` ✅ / \`yarn build\` ✅