### PR TITLE
feat(runtime): generic endpoints type on useRuntime / PluginRuntime (0.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/spec/PLUGIN_RUNTIME.md
+++ b/spec/PLUGIN_RUNTIME.md
@@ -149,6 +149,7 @@ interface BrowserPluginRuntime {
   log:     { debug; info; warn; error };
   openUrl: (url: string) => void;                        // target=_blank + noopener,noreferrer
   dispatch<T = unknown>(args: object): Promise<T>;       // POST to this plugin's dispatch route
+  endpoints?: Readonly<Record<string, string>>;          // multi-URL escape hatch (optional)
 }
 ```
 
@@ -165,6 +166,27 @@ const json = await dispatch<{ ok: boolean; bookmarks: Bookmark[] }>({
 ```
 
 The shape of `args` is whatever the plugin's server handler expects (typically a discriminated union by `kind` — see "Action discriminator pattern" below).
+
+### `endpoints` (optional, multi-URL plugins)
+
+For plugins that need more than the single `dispatch` endpoint — typically REST-shaped plugins with several sub-resources (`items`, `items/:id`, `columns`, …) where folding everything through `dispatch(args)` would force a server-side rewrite. The host populates this map at provide time; single-dispatch plugins (the common runtime-loaded shape) leave it `undefined`.
+
+```ts
+// Plugin declares its expected shape
+interface TodoEndpoints {
+  list: string;
+  items: string;
+  item: string;       // route pattern with :id
+  columns: string;
+}
+
+// Plugin reads via the runtime
+const endpoints = runtime.endpoints as TodoEndpoints | undefined;
+if (!endpoints) throw new Error("host did not provide TodoEndpoints");
+await fetch(endpoints.items, { method: "POST", body });
+```
+
+The protocol keeps `endpoints` typed as `Record<string, string>` so it doesn't need to know plugin-specific keys; plugins recover named access via a local interface + `as` cast. The host is responsible for populating the same key set the plugin expects.
 
 ## Action discriminator pattern (recommended)
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -75,14 +75,26 @@ export interface PluginFetchJsonOptions<T> extends PluginFetchOptions {
 }
 
 /**
+ * Default shape for `PluginRuntime['endpoints']` — see
+ * `BrowserPluginRuntime['endpoints']` for the same rationale on the
+ * Vue side. Plugin authors pin a tighter shape via the `E` type
+ * parameter on `PluginRuntime<E>` / `definePlugin<…, E>`.
+ */
+export type DefaultServerPluginEndpoints = Readonly<Record<string, unknown>>;
+
+/**
  * Runtime handed to a plugin's `definePlugin(setup)` factory at load time.
  * The plugin closes over the destructured fields; handlers reference them
  * as bare API calls (no `context.` indirection).
  *
  * `pubsub` / `files.*` / `log` are scoped per plugin. The plugin cannot
  * spell another plugin's channel or file path through the API.
+ *
+ * Optional `E` type parameter pins the `endpoints` map's shape. Defaults
+ * to `DefaultServerPluginEndpoints` for backward compatibility — non-
+ * generic usage (`PluginRuntime`) keeps working unchanged (0.3.2).
  */
-export interface PluginRuntime {
+export interface PluginRuntime<E = DefaultServerPluginEndpoints> {
   /**
    * Scoped pub/sub publisher. `publish("foo", payload)` is internally
    * routed to channel `plugin:<pkg>:foo`. The plugin cannot publish to
@@ -154,7 +166,7 @@ export interface PluginRuntime {
    * Single-dispatch plugins (the common runtime-loaded shape) leave
    * this `undefined`.
    */
-  endpoints?: Readonly<Record<string, string>>;
+  endpoints?: E;
 }
 
 // ============================================================================

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -141,6 +141,20 @@ export interface PluginRuntime {
    */
   fetchJson(url: string, opts?: PluginFetchOptions): Promise<unknown>;
   fetchJson<T>(url: string, opts: PluginFetchJsonOptions<T>): Promise<T>;
+
+  /**
+   * Optional URL map mirroring `BrowserPluginRuntime.endpoints` —
+   * see that field for the rationale. Server-side plugin handlers
+   * rarely need this (they typically service the dispatch endpoint
+   * directly), but the field is defined symmetrically so a
+   * cross-cutting plugin (e.g. one that calls into another plugin's
+   * URL via `runtime.fetch`) doesn't have to import the host's
+   * config.
+   *
+   * Single-dispatch plugins (the common runtime-loaded shape) leave
+   * this `undefined`.
+   */
+  endpoints?: Readonly<Record<string, string>>;
 }
 
 // ============================================================================

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -16,13 +16,30 @@ export * from "./index";
 // ============================================================================
 
 /**
+ * Default shape for `BrowserPluginRuntime['endpoints']` when the
+ * caller doesn't pin a specific plugin's endpoint type. Values are
+ * `unknown` because hosts populate the map with plugin-specific
+ * shapes (e.g. mulmoclaude provides `{ method, url }` records); each
+ * plugin pins the precise shape via the `E` type parameter on
+ * `useRuntime<E>()` below.
+ */
+export type DefaultPluginEndpoints = Readonly<Record<string, unknown>>;
+
+/**
  * Runtime exposed to a plugin's Vue components via `useRuntime()`. The
  * host wraps a plugin's component subtree in a scope provider that
  * `provide`s a per-plugin instance to `PLUGIN_RUNTIME_KEY`.
  *
+ * Optional type parameter `E` pins the `endpoints` map's shape so a
+ * plugin author can write `useRuntime<TodoEndpoints>()` and read
+ * `runtime.endpoints.list.url` without an `as` cast (0.3.2). Defaults
+ * to `DefaultPluginEndpoints` for backward compatibility — non-generic
+ * usage (`BrowserPluginRuntime` / `useRuntime()`) keeps working
+ * unchanged.
+ *
  * Spec: https://github.com/receptron/mulmoclaude/issues/1110
  */
-export interface BrowserPluginRuntime {
+export interface BrowserPluginRuntime<E = DefaultPluginEndpoints> {
   /**
    * Scoped pub/sub client. `subscribe("foo", handler)` is internally
    * routed to channel `plugin:<pkg>:foo`. Returns an unsubscribe
@@ -69,18 +86,23 @@ export interface BrowserPluginRuntime {
    * where folding everything through `dispatch(args)` would force a
    * server-side rewrite to a single action-discriminated POST.
    *
-   * Each entry's value is the full URL the plugin should call
-   * (`apiPost(endpoints.items, body)` etc.); the host populates the
-   * map at provide time. Single-dispatch plugins (the common runtime-
-   * loaded shape) leave it `undefined` and rely on `dispatch` alone.
+   * The host populates the map at provide time; the value shape is
+   * host-defined (mulmoclaude provides `{ method, url }` records).
+   * Single-dispatch plugins (the common runtime-loaded shape) leave
+   * it `undefined` and rely on `dispatch` alone.
    *
-   * The key set is plugin-defined and host-populated. Plugins that
-   * declare their own `<Name>Endpoints` type can do
-   * `runtime.endpoints as MyEndpoints` to recover named access; the
-   * type stays `Record<string, string>` here so the protocol doesn't
-   * need to know plugin-specific keys.
+   * Pin the shape via `useRuntime<E>()`'s type parameter:
+   *
+   * ```ts
+   * interface TodoEndpoints { list: { method: "GET"; url: string } }
+   * const runtime = useRuntime<TodoEndpoints>();
+   * runtime.endpoints?.list.url; // ← typed, no cast
+   * ```
+   *
+   * Defaults to `DefaultPluginEndpoints` (Readonly<Record<string,
+   * unknown>>) when called without a type parameter.
    */
-  endpoints?: Readonly<Record<string, string>>;
+  endpoints?: E;
 }
 
 /**
@@ -94,15 +116,26 @@ export const PLUGIN_RUNTIME_KEY: InjectionKey<BrowserPluginRuntime> = Symbol("gu
  * Composable that returns the plugin's `BrowserPluginRuntime`. Throws
  * a descriptive error if called outside the host's scope provider so
  * misuse fails loudly during development.
+ *
+ * Pass a plugin-specific endpoints type as the optional `E` type
+ * parameter to drop the cast on `runtime.endpoints`:
+ *
+ * ```ts
+ * const runtime = useRuntime<TodoEndpoints>();
+ * runtime.endpoints?.list.url;  // ← typed, no `as`
+ * ```
+ *
+ * Without the type parameter, `endpoints` falls back to
+ * `DefaultPluginEndpoints` (Readonly<Record<string, unknown>>).
  */
-export function useRuntime(): BrowserPluginRuntime {
+export function useRuntime<E = DefaultPluginEndpoints>(): BrowserPluginRuntime<E> {
   const runtime = inject(PLUGIN_RUNTIME_KEY);
   if (!runtime) {
     throw new Error(
       "useRuntime() called outside of <PluginScopedRoot> — the host must provide PLUGIN_RUNTIME_KEY",
     );
   }
-  return runtime;
+  return runtime as BrowserPluginRuntime<E>;
 }
 
 // ============================================================================

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -61,6 +61,26 @@ export interface BrowserPluginRuntime {
    * Throws on network error or non-2xx response.
    */
   dispatch<T = unknown>(args: object): Promise<T>;
+
+  /**
+   * Optional URL map for plugins that need more than the single
+   * `dispatch` endpoint — typically REST-shaped plugins with
+   * multiple sub-resources (`items`, `items/:id`, `columns`, …)
+   * where folding everything through `dispatch(args)` would force a
+   * server-side rewrite to a single action-discriminated POST.
+   *
+   * Each entry's value is the full URL the plugin should call
+   * (`apiPost(endpoints.items, body)` etc.); the host populates the
+   * map at provide time. Single-dispatch plugins (the common runtime-
+   * loaded shape) leave it `undefined` and rely on `dispatch` alone.
+   *
+   * The key set is plugin-defined and host-populated. Plugins that
+   * declare their own `<Name>Endpoints` type can do
+   * `runtime.endpoints as MyEndpoints` to recover named access; the
+   * type stays `Record<string, string>` here so the protocol doesn't
+   * need to know plugin-specific keys.
+   */
+  endpoints?: Readonly<Record<string, string>>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add optional `E` type parameter to `BrowserPluginRuntime<E>` / `useRuntime<E>()` (Vue side) and `PluginRuntime<E>` (server side) so plugin authors pin the `endpoints` map's shape without an `as` cast.
- Patch version (0.3.2): additive only — defaults preserve every existing call site's behavior. No runtime changes.
- Catches `main` up with the **0.3.1 endpoints field** (the previous release was published from `feat/runtime-endpoints-multi-url` but never merged — this branch cherry-picked that commit so `main` finally reflects the npm artifact).

## Items to confirm / review

- [ ] Generic on the Vue side carries the change; the server-side `PluginRuntime<E>` is symmetrical but `definePlugin`'s signature stays non-generic (server-side authors rarely use `endpoints` — the runtime hands typed access via `runtime.endpoints` if they pass a generic type, otherwise default `Record<string, unknown>` works through cast)
- [ ] Default `DefaultPluginEndpoints` / `DefaultServerPluginEndpoints` = `Readonly<Record<string, unknown>>` keeps existing callers compiling unchanged
- [ ] Already published to npm as 0.3.2 — `npm view gui-chat-protocol version` returns `0.3.2`

## Usage

```ts
// Old:
const endpoints = useRuntime().endpoints as TodoEndpoints; // cast required

// New:
const runtime = useRuntime<TodoEndpoints>();
runtime.endpoints?.list.url; // ← typed, no `as`
```

## Backward compatibility

- `BrowserPluginRuntime` (no generic) → `BrowserPluginRuntime<DefaultPluginEndpoints>` (default substituted, same shape as 0.3.1)
- `useRuntime()` → `useRuntime<DefaultPluginEndpoints>()` (default substituted, same return type as 0.3.1)
- The published artifact's `.d.ts` exports both `DefaultPluginEndpoints` and the generic forms

## Test plan

- [x] `yarn build` succeeds, generic emitted in `dist/vue.d.ts`
- [x] Published to npm: `npm view gui-chat-protocol@0.3.2 version` → `0.3.2`
- [x] Mulmoclaude consumer PR ([receptron/mulmoclaude#1154](https://github.com/receptron/mulmoclaude/pull/1154)) bumps the dep + drops cast sites — passes typecheck / lint / tests / e2e