### PR TITLE
docs(types): clarify data vs jsonData on ToolResult

### DIFF
--- a/spec/API_REFERENCE.md
+++ b/spec/API_REFERENCE.md
@@ -32,17 +32,20 @@ interface ToolResult<T, J> {
 }
 ```
 
-#### Rendering vs narrate-only
+#### `data` gates rendering
 
-Hosts treat `data` and `jsonData` as the two "view payload" signals. Setting **either** indicates the plugin wants a GUI card rendered for this result; setting **neither** makes the result *narrate-only* — `message` / `instructions` reach the LLM, but no card is shown. Narrate-only is the right shape for actions whose effect is purely informational for the LLM (fetching a list the LLM will summarize next turn, returning a validation error, etc.).
+**Setting `data` is the host's render-eligibility signal**: a result with `data` renders a GUI card; a result without `data` is *narrate-only* — `message` / `instructions` reach the LLM, but no card is shown. Narrate-only is the right shape for actions whose effect is purely informational for the LLM (fetching a list the LLM will summarize next turn, returning a validation error, etc.).
 
-#### Choosing `data` vs `jsonData` vs both
+`jsonData` is orthogonal to rendering. It's the JSON-serializable copy returned to the LLM alongside `message` / `instructions`, used when the model needs to read the structured result back on subsequent turns. Setting `jsonData` alone does NOT cause a card to render — pair it with `data` if you also want the view to bind the same shape.
 
-| Field | Audience | When to set it |
+#### What to set
+
+| Combination | Behaviour | Use when |
 |---|---|---|
-| `data` | Plugin's view / preview component | The view needs a typed payload that the LLM should NOT see. |
-| `jsonData` | The LLM (returned alongside `message` / `instructions`) | The LLM needs to read the structured result back on subsequent turns. |
-| **Both** | View AND LLM (same shape) | The same payload needs to reach both audiences — set `data: payload, jsonData: payload`. |
+| `data` only | Card renders; LLM sees only `message` | The view needs a typed payload the LLM doesn't need to recall. |
+| Neither | Narrate-only; no card | The action is informational for the LLM (list lookups, validation errors). |
+| Both (`data: payload, jsonData: payload`) | Card renders AND LLM reads the same payload back | The view and the LLM both reason over the same shape (quiz definitions, form specs). |
+| `jsonData` only | No card; LLM gets a JSON copy | Uncommon — equivalent to narrate-only for the GUI. |
 
 Worked examples:
 

--- a/spec/API_REFERENCE.md
+++ b/spec/API_REFERENCE.md
@@ -32,6 +32,31 @@ interface ToolResult<T, J> {
 }
 ```
 
+#### Rendering vs narrate-only
+
+Hosts treat `data` and `jsonData` as the two "view payload" signals. Setting **either** indicates the plugin wants a GUI card rendered for this result; setting **neither** makes the result *narrate-only* — `message` / `instructions` reach the LLM, but no card is shown. Narrate-only is the right shape for actions whose effect is purely informational for the LLM (fetching a list the LLM will summarize next turn, returning a validation error, etc.).
+
+#### Choosing `data` vs `jsonData` vs both
+
+| Field | Audience | When to set it |
+|---|---|---|
+| `data` | Plugin's view / preview component | The view needs a typed payload that the LLM should NOT see. |
+| `jsonData` | The LLM (returned alongside `message` / `instructions`) | The LLM needs to read the structured result back on subsequent turns. |
+| **Both** | View AND LLM (same shape) | The same payload needs to reach both audiences — set `data: payload, jsonData: payload`. |
+
+Worked examples:
+
+```ts
+// Card with view-only payload (LLM only needs to know it succeeded)
+return { message: "Generated image", data: { url, prompt } };
+
+// Narrate-only (no card)
+return { message: `Found ${reports.length} reports`, instructions: "..." };
+
+// Card + LLM-readable payload — same payload, two audiences
+return { message: "Form presented", data: form, jsonData: form, instructions: "..." };
+```
+
 ### ToolContext
 
 ```typescript

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,49 @@ export type BackendType =
 // ============================================================================
 
 /**
- * Result returned from plugin execution
+ * Result returned from plugin execution.
+ *
+ * ### Rendering vs narrate-only
+ *
+ * Hosts treat `data` and `jsonData` as the two "view payload"
+ * signals — setting **either** indicates the plugin wants a GUI
+ * card rendered for this result; setting **neither** makes the
+ * result *narrate-only* (`message` / `instructions` flow to the
+ * LLM, but no card is shown). Use narrate-only for actions whose
+ * effect is purely informational for the LLM — fetching a list
+ * the LLM will summarize, validation-error returns, etc.
+ *
+ * ### Choosing `data` vs `jsonData` vs both
+ *
+ * - **`data`** — typed payload consumed by the plugin's view /
+ *   preview component (Vue, React, …). The LLM does NOT see
+ *   `data` — it's a private channel from the plugin's executor
+ *   to its UI.
+ * - **`jsonData`** — JSON-serializable shape returned to the LLM
+ *   alongside `message` / `instructions`. Use when the LLM needs
+ *   to read the structured result back on subsequent turns
+ *   (e.g. a quiz definition the LLM must reference, a form spec
+ *   the LLM will recall).
+ * - **Both** — set when the same payload needs to reach both
+ *   audiences. Pattern: `data: payload, jsonData: payload`. The
+ *   view binds the typed shape; the LLM gets the JSON.
+ *
+ * ### Worked examples
+ *
+ * Card + view-only payload (LLM only needs to know it succeeded):
+ * ```ts
+ * return { message: "Generated image", data: { url, prompt } };
+ * ```
+ *
+ * Narrate-only (LLM-readable, no card):
+ * ```ts
+ * return { message: `Found ${reports.length} reports`, instructions: "..." };
+ * ```
+ *
+ * Card + LLM-readable payload (same payload, two audiences):
+ * ```ts
+ * return { message: "Form presented", data: form, jsonData: form, instructions: "..." };
+ * ```
  */
 export interface ToolResult<T = unknown, J = unknown> {
   toolName?: string; // name of the tool that generated this result
@@ -35,12 +77,27 @@ export interface ToolResult<T = unknown, J = unknown> {
   message: string; // status message sent back to the LLM about the tool execution result
   title?: string;
   action?: string; // sub-action / verb the tool was invoked with (e.g. "openApp", "addEntry"); used by hosts to label multi-feature tool results in the UI
-  jsonData?: J; // data to be passed to the LLM
+  /**
+   * JSON-serializable result the LLM reads back alongside
+   * `message` / `instructions`. Setting this (or `data`) signals
+   * the host to render a GUI card; setting neither makes the
+   * result narrate-only. See the interface-level docs for the
+   * choice between `data`, `jsonData`, and both.
+   */
+  jsonData?: J;
   instructions?: string; // follow-up instructions for the LLM
   instructionsRequired?: boolean; // if true, instructions will be sent even if suppressInstructions is enabled
   updating?: boolean; // if true, updates existing result instead of creating new one
   cancelled?: boolean; // if true, operation was cancelled by the user and should not be added to UI
-  data?: T; // tool specific data (for views, not visible to the LLM)
+  /**
+   * Typed payload consumed by the plugin's view / preview
+   * component. Not visible to the LLM. Setting this (or
+   * `jsonData`) signals the host to render a GUI card; setting
+   * neither makes the result narrate-only. See the
+   * interface-level docs for the choice between `data`,
+   * `jsonData`, and both.
+   */
+  data?: T;
   viewState?: Record<string, unknown>; // tool specific view state
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,39 +29,42 @@ export type BackendType =
 /**
  * Result returned from plugin execution.
  *
- * ### Rendering vs narrate-only
+ * ### `data` gates rendering
  *
- * Hosts treat `data` and `jsonData` as the two "view payload"
- * signals — setting **either** indicates the plugin wants a GUI
- * card rendered for this result; setting **neither** makes the
- * result *narrate-only* (`message` / `instructions` flow to the
- * LLM, but no card is shown). Use narrate-only for actions whose
- * effect is purely informational for the LLM — fetching a list
- * the LLM will summarize, validation-error returns, etc.
+ * `data` is the host's render-eligibility signal: setting it
+ * means "render a GUI card for this result"; omitting it makes
+ * the result *narrate-only* (`message` / `instructions` flow to
+ * the LLM, but no card is shown). Use narrate-only for actions
+ * whose effect is purely informational for the LLM — fetching a
+ * list the LLM will summarize, validation-error returns, etc.
  *
- * ### Choosing `data` vs `jsonData` vs both
+ * `jsonData` is orthogonal: it's the JSON-serializable copy
+ * returned to the LLM alongside `message` / `instructions` for
+ * cases where the model needs to read the structured result back
+ * on subsequent turns. Setting `jsonData` does NOT, by itself,
+ * cause a card to render — pair it with `data` if you also want
+ * the view to bind the same shape.
  *
- * - **`data`** — typed payload consumed by the plugin's view /
- *   preview component (Vue, React, …). The LLM does NOT see
- *   `data` — it's a private channel from the plugin's executor
- *   to its UI.
- * - **`jsonData`** — JSON-serializable shape returned to the LLM
- *   alongside `message` / `instructions`. Use when the LLM needs
- *   to read the structured result back on subsequent turns
- *   (e.g. a quiz definition the LLM must reference, a form spec
- *   the LLM will recall).
- * - **Both** — set when the same payload needs to reach both
- *   audiences. Pattern: `data: payload, jsonData: payload`. The
- *   view binds the typed shape; the LLM gets the JSON.
+ * ### Choosing what to set
+ *
+ * - **`data` only** — render a card; the LLM only sees `message`.
+ * - **Neither** — narrate-only; no card.
+ * - **Both** (`data: payload, jsonData: payload`) — render a card
+ *   AND let the LLM read the same payload back. Use this when
+ *   the view and the LLM need to reason over the same shape
+ *   (e.g. a quiz definition, a form spec).
+ * - **`jsonData` only** — uncommon; the LLM gets a JSON copy with
+ *   no card. Equivalent to narrate-only as far as the GUI is
+ *   concerned.
  *
  * ### Worked examples
  *
- * Card + view-only payload (LLM only needs to know it succeeded):
+ * Card with view-only payload (LLM only needs to know it succeeded):
  * ```ts
  * return { message: "Generated image", data: { url, prompt } };
  * ```
  *
- * Narrate-only (LLM-readable, no card):
+ * Narrate-only (no card):
  * ```ts
  * return { message: `Found ${reports.length} reports`, instructions: "..." };
  * ```
@@ -79,10 +82,10 @@ export interface ToolResult<T = unknown, J = unknown> {
   action?: string; // sub-action / verb the tool was invoked with (e.g. "openApp", "addEntry"); used by hosts to label multi-feature tool results in the UI
   /**
    * JSON-serializable result the LLM reads back alongside
-   * `message` / `instructions`. Setting this (or `data`) signals
-   * the host to render a GUI card; setting neither makes the
-   * result narrate-only. See the interface-level docs for the
-   * choice between `data`, `jsonData`, and both.
+   * `message` / `instructions`. Orthogonal to rendering — only
+   * `data` causes a card to render. Set this when the LLM needs
+   * to recall the structured result on subsequent turns; pair
+   * with `data` to also render a card bound to the same shape.
    */
   jsonData?: J;
   instructions?: string; // follow-up instructions for the LLM
@@ -91,11 +94,10 @@ export interface ToolResult<T = unknown, J = unknown> {
   cancelled?: boolean; // if true, operation was cancelled by the user and should not be added to UI
   /**
    * Typed payload consumed by the plugin's view / preview
-   * component. Not visible to the LLM. Setting this (or
-   * `jsonData`) signals the host to render a GUI card; setting
-   * neither makes the result narrate-only. See the
-   * interface-level docs for the choice between `data`,
-   * `jsonData`, and both.
+   * component. Not visible to the LLM. **Setting `data` is the
+   * host's render-eligibility signal** — a result without `data`
+   * is treated as narrate-only and no card is rendered. See the
+   * interface-level docs for the full rule and worked examples.
    */
   data?: T;
   viewState?: Record<string, unknown>; // tool specific view state


### PR DESCRIPTION
## Summary

The two view-payload fields on `ToolResult` (`data`, `jsonData`) lack enough docs for plugin authors to make the right choice. Inline trailing comments cover what each carries, but not the host-level gating semantics, the audience split, or the "set both" pattern.

Surfaced while auditing host-side bridge behaviour in [`receptron/mulmoclaude#1178`](https://github.com/receptron/mulmoclaude/pull/1178). Out of 15 plugin endpoints, **three** different conventions were live:

| Plugin | Sets |
|---|---|
| `presentForm` | both |
| `manageAccounting` (visible actions) | `data` only |
| `putQuestions` (quiz, npm: `@mulmochat-plugin/quiz`) | `jsonData` only |

The mismatch was silent until the host's gating rule changed — at which point quiz cards stopped rendering. Documenting the protocol contract here removes the guesswork.

## What changed

- `src/types.ts` — JSDoc on `ToolResult`, `data`, and `jsonData`. Three subsections: rendering vs narrate-only, audience split, three worked examples.
- `spec/API_REFERENCE.md` — same guidance mirrored in the spec, with a small table and the same examples.

No code or shape changes; types are byte-identical.

## Test plan

- [x] `yarn build` clean (declaration files regenerate, JSDoc surfaces in IDE)
- [ ] Smoke-check the JSDoc renders correctly on hover in VS Code / Cursor for `ToolResult.data` and `ToolResult.jsonData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)