### PR TITLE
fix(vue): let createUseT degrade instead of throwing (1.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -5,7 +5,7 @@
  * Use these types when building Vue-based plugin UI components.
  */
 
-import { computed, inject, type Component, type ComputedRef, type InjectionKey, type Ref } from "vue";
+import { computed, inject, ref, type Component, type ComputedRef, type InjectionKey, type Ref } from "vue";
 import type { ToolPluginCore, InputHandler } from "./index";
 
 // Re-export all core types
@@ -160,14 +160,20 @@ export function pickMessages<M extends Record<string, unknown> & { en: unknown }
  * Build a plugin's `useT()` from its own message tables.
  *
  * Plugin-local i18n: the tables travel with the plugin bundle and are never
- * merged into the host's i18n instance. The plugin reads the host's locale via
- * `useRuntime()` and looks up its own table reactively.
+ * merged into the host's i18n instance. The plugin reads the host's locale off
+ * the runtime and looks up its own table reactively.
  *
  * ```ts
  * import en from "./en";
  * import ja from "./ja";
  * export const useT = createUseT({ en, ja });
  * ```
+ *
+ * Degrades instead of throwing: with no host runtime provided it falls back to
+ * a static `"en"` locale, so a plugin's components still render standalone (in
+ * a storybook, a unit test, or a page mounted outside the host's plugin scope).
+ * `useRuntime()` throws in that situation by design — it is the accessor for
+ * code that genuinely requires the host. Translation lookup does not.
  *
  * A plugin that needs real vue-i18n features (plural forms, linked messages)
  * should spin up its own `createI18n()` instead.
@@ -176,7 +182,8 @@ export function createUseT<M extends Record<string, unknown> & { en: unknown }>(
   messages: M,
 ): () => ComputedRef<M[keyof M]> {
   return function useT(): ComputedRef<M[keyof M]> {
-    const { locale } = useRuntime();
+    const runtime = inject(PLUGIN_RUNTIME_KEY, undefined);
+    const locale: Ref<string> = runtime?.locale ?? ref("en");
     return computed(() => pickMessages(messages, locale.value));
   };
 }


### PR DESCRIPTION
## Summary

1.0.0 の `createUseT` はロケールを `useRuntime()` 経由で読んでいましたが、これはホストが `PLUGIN_RUNTIME_KEY` を provide していないと **throw** します。

置き換え対象だった mulmoclaude の8プラグインを実測したところ、**設計が1つではなく2つ混在**していました:

| 取得方法 | プラグイン | 未提供時 |
|---|---|---|
| `useRuntime()` | bookmarks / recipe-book / spotify | **throw** |
| `inject(PLUGIN_RUNTIME_KEY, undefined)` | chart / form / html / markdown / mulmoscript | **`ref("en")` で描画継続** |

後者5つに 1.0.0 をそのまま適用すると、**standalone で描画できていたものが例外になる機能後退**を持ち込みます。

翻訳のルックアップはホストを必須としません（ランタイムが無い＝追従すべきロケールが無いだけ）。`useRuntime()` は「ホストが本当に必要なコード」が声高に失敗するためのアクセサとして残し、`createUseT` は default 付き inject に変更します。

## Items to Confirm / Review

- **1.0.0 からの挙動変更です。** ただし throw しなくなる方向＝より寛容になるだけで、既存の呼び出し側を壊しません。1.0.0 は公開直後で利用者ゼロです。
- この変更により、**現在 throw している3プラグイン（bookmarks / recipe-book / spotify）は graceful 側に揃います**。ホスト未提供時に例外ではなく英語で描画されるようになります。意図的に throw させていたのであれば教えてください。

## 補足（1.0.0 の記述の訂正）

1.0.0 の PR / Release Notes に「置き換え対象はすべて `locale in messages` を使っていた」と書きましたが**誤り**でした。実際は `in` が4つ、`hasOwnProperty` / `Object.hasOwn` が4つです。Release Notes には訂正を追記済みです。

## テスト

`tsc --noEmit` / `eslint` / `vite build` / テスト、すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)