### PR TITLE
test(vue): cover createUseT itself, not just its pure half

### DIFF
--- a/test/test_createUseT.ts
+++ b/test/test_createUseT.ts
@@ -1,0 +1,83 @@
+// `createUseT` is what plugins actually call, and 1.1.0 changed how it behaves
+// when no host runtime is present (it used to throw via `useRuntime()`, it now
+// falls back to English). That change is the whole reason plugins could adopt
+// it, so it needs to be pinned rather than described.
+//
+// `app.runWithContext()` lets `inject()` resolve outside a component's setup,
+// so these run headless — no DOM, no mount.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createApp, ref, type Ref } from "vue";
+
+import {
+  createUseT,
+  PLUGIN_RUNTIME_KEY,
+  type BrowserPluginRuntime,
+} from "../src/vue";
+
+const MESSAGES = {
+  en: { hello: "Hello" },
+  ja: { hello: "こんにちは" },
+  de: { hello: "Hallo" },
+} as const;
+
+/** Minimal stand-in for the host runtime — only `locale` is read here. */
+function fakeRuntime(locale: Ref<string>): BrowserPluginRuntime {
+  return {
+    locale,
+    pubsub: { subscribe: () => () => {} },
+    log: { debug() {}, info() {}, warn() {}, error() {} },
+    openUrl() {},
+    dispatch: async () => ({}),
+  };
+}
+
+function withRuntime<T>(locale: Ref<string>, fn: () => T): T {
+  const app = createApp({});
+  app.provide(PLUGIN_RUNTIME_KEY, fakeRuntime(locale));
+  return app.runWithContext(fn);
+}
+
+describe("createUseT", () => {
+  it("resolves the table for the host's locale", () => {
+    const useT = createUseT(MESSAGES);
+    const t = withRuntime(ref("ja"), () => useT());
+    assert.deepEqual(t.value, { hello: "こんにちは" });
+  });
+
+  it("tracks the host locale reactively", () => {
+    const useT = createUseT(MESSAGES);
+    const locale = ref("en");
+    const t = withRuntime(locale, () => useT());
+    assert.deepEqual(t.value, { hello: "Hello" });
+    locale.value = "de";
+    assert.deepEqual(
+      t.value,
+      { hello: "Hallo" },
+      "computed should re-evaluate when the host switches locale",
+    );
+  });
+
+  it("falls back to English for a locale the plugin doesn't ship", () => {
+    const useT = createUseT(MESSAGES);
+    const t = withRuntime(ref("fr"), () => useT());
+    assert.deepEqual(t.value, { hello: "Hello" });
+  });
+
+  // The 1.1.0 behaviour change: `useRuntime()` throws here, `createUseT` must
+  // not — a plugin's components have to render standalone (storybook, unit
+  // test, a page mounted outside the host's plugin scope).
+  it("falls back to English instead of throwing when no host runtime is provided", () => {
+    const useT = createUseT(MESSAGES);
+    const app = createApp({});
+    const t = app.runWithContext(() => useT());
+    assert.deepEqual(t.value, { hello: "Hello" });
+  });
+
+  it("does not treat an inherited property name as a locale", () => {
+    const useT = createUseT(MESSAGES);
+    const t = withRuntime(ref("toString"), () => useT());
+    assert.deepEqual(t.value, { hello: "Hello" });
+  });
+});


### PR DESCRIPTION
## Summary

既存のテストは `pickMessages` だけを対象にし、`createUseT` は「`useRuntime()` + `computed()` の2行のグルーだから」とコメントで明示的に除外していました。

しかし**その2行こそ 1.1.0 で変更した箇所**です（ホスト未提供時に throw → 英語フォールバック）。mulmoclaude 側で**3プラグインの挙動をこれを根拠に変更した**にもかかわらず、その関数は一度も実行されていませんでした。

`app.runWithContext()` を使うと `inject()` がコンポーネントの setup 外でも解決できるため、**DOM もマウントも不要**でヘッドレスに検証できます。

## カバーした挙動

| ケース | 期待 |
|---|---|
| ホストのロケールが提供されている | そのロケールの表を返す |
| ホストがロケールを切り替える | computed が再評価される |
| プラグインが持たないロケール | 英語にフォールバック |
| 継承プロパティ名（`toString`） | ロケール扱いしない |
| **ランタイム自体が無い** | **throw せず英語にフォールバック**（1.1.0 の変更点） |

## 変異テストによる検証

「テストは対象を壊したときに落ちること」を確認しました。`createUseT` を 1.0.0 の `useRuntime()` 版に戻すと:

- ランタイム無しのケース → **fail 1**（赤くなる）
- 他4件 → 緑のまま

つまりこのテストは意図した挙動を実際に捕まえており、壊れたコードでも通ってしまう類のものではありません。復元後は全件 green です。

## テスト

`tsc --noEmit` / `eslint` / 全テスト green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)