### PR TITLE
feat: add createSerialLock() for serialising async work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui-chat-protocol",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Protocol types for GUI chat plugins - framework-agnostic core with Vue and React adapters",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from "./types";
 export * from "./inputHandlers";
 export * from "./schema";
 export * from "./runtime";
+export * from "./serialLock";

--- a/src/serialLock.ts
+++ b/src/serialLock.ts
@@ -1,0 +1,36 @@
+/**
+ * Serial lock — run async work one at a time.
+ *
+ * Plugins that do read-modify-write against their own files need the
+ * steps serialised, or two parallel calls both read the same snapshot
+ * and one update is silently dropped.
+ */
+
+/** Runs `fn` after every previously-queued call has settled. */
+export type SerialLock = <T>(fn: () => Promise<T>) => Promise<T>;
+
+/**
+ * Creates an independent lock. Each call queues behind the previous one,
+ * so a read-modify-write cycle cannot interleave with another.
+ *
+ * ```ts
+ * const withWriteLock = createSerialLock();
+ * await withWriteLock(async () => {
+ *   const current = await read();
+ *   await write(current + 1);
+ * });
+ * ```
+ *
+ * A rejected call does not poison the queue: the chain head swallows the
+ * rejection so the next caller still runs, while the caller that queued
+ * the failing work still sees its own error (we return the un-swallowed
+ * promise).
+ */
+export function createSerialLock(): SerialLock {
+  let tail: Promise<unknown> = Promise.resolve();
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = tail.catch(() => undefined).then(fn);
+    tail = next.catch(() => undefined);
+    return next;
+  };
+}

--- a/test/test_serialLock.ts
+++ b/test/test_serialLock.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createSerialLock } from "../src/serialLock";
+
+const defer = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+/** Lets every already-queued microtask and timer callback run. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("does not start the next call until the current one settles", async () => {
+  const lock = createSerialLock();
+  const order: string[] = [];
+  const held = defer<void>();
+
+  const first = lock(async () => {
+    order.push("first:start");
+    await held.promise;
+    order.push("first:end");
+  });
+  const second = lock(async () => {
+    order.push("second:start");
+  });
+
+  try {
+    await tick();
+    // `second` is queued behind `first`, which is still awaiting `held`.
+    assert.deepEqual(order, ["first:start"]);
+  } finally {
+    held.resolve();
+  }
+
+  await Promise.all([first, second]);
+  assert.deepEqual(order, ["first:start", "first:end", "second:start"]);
+});
+
+test("serialises read-modify-write so no update is dropped", async () => {
+  const lock = createSerialLock();
+  let counter = 0;
+  const increment = () =>
+    lock(async () => {
+      const current = counter;
+      await tick();
+      counter = current + 1;
+    });
+
+  await Promise.all([increment(), increment(), increment()]);
+  assert.equal(counter, 3);
+});
+
+test("a rejected call does not poison the queue", async () => {
+  const lock = createSerialLock();
+  const failing = lock(async () => {
+    throw new Error("boom");
+  });
+
+  await assert.rejects(failing, /boom/);
+  assert.equal(await lock(async () => "ok"), "ok");
+});
+
+test("the caller of failing work sees its own error", async () => {
+  const lock = createSerialLock();
+  const failing = lock(async () => {
+    throw new Error("mine");
+  });
+  const following = lock(async () => "unaffected");
+
+  await assert.rejects(failing, /mine/);
+  assert.equal(await following, "unaffected");
+});
+
+test("locks are independent of each other", async () => {
+  const slow = createSerialLock();
+  const other = createSerialLock();
+  const held = defer<void>();
+  const order: string[] = [];
+
+  const blocked = slow(async () => {
+    await held.promise;
+    order.push("slow");
+  });
+
+  try {
+    await other(async () => {
+      order.push("other");
+    });
+    // `other` finished while `slow` still held its own lock.
+    assert.deepEqual(order, ["other"]);
+  } finally {
+    held.resolve();
+  }
+
+  await blocked;
+  assert.deepEqual(order, ["other", "slow"]);
+});
+
+test("resolves with the callback's value", async () => {
+  const lock = createSerialLock();
+  assert.equal(await lock(async () => 42), 42);
+});


### PR DESCRIPTION
## Summary

Adds `createSerialLock()` — a small factory that queues async work so it runs one at a time.

Plugin authors doing read-modify-write against their own files need this: two parallel calls otherwise read the same snapshot and one update is silently dropped. Today three places in `receptron/mulmoclaude` carry a byte-identical hand-rolled copy — `bookmarks-plugin`, `recipe-book-plugin`, and the `create-mulmoclaude-plugin` scaffold template — so every new plugin generated from the scaffold inherits another copy.

```ts
const withWriteLock = createSerialLock();

await withWriteLock(async () => {
  const current = await read();
  await write(current + 1);   // cannot interleave with another call
});
```

## Items to Confirm / Review

- **The `.catch(() => undefined)` on the chain head is load-bearing** and easy to get wrong when hand-copied: it stops a rejected call from poisoning the queue, while the caller that queued the failing work still sees its own error (we return the un-swallowed promise). Both properties are pinned by tests.
- Locks are independent instances (no module-level shared state), so two plugins can't block each other.
- Exported from the root entry via `src/index.ts` (`export * from "./serialLock"`), matching how `runtime` / `schema` are surfaced. No new subpath.
- Version bumped 1.1.0 → **1.2.0** (additive surface).

## Verification

- `yarn test` — **16 pass / 0 fail** (6 new: ordering, no-dropped-update, rejection doesn't poison the queue, caller sees its own error, lock independence, resolves the callback value)
- **Mutation-verified**: replacing `tail.catch(...).then(fn)` with `fn()` (i.e. dropping the serialisation) turns the read-modify-write test red — `actual: 1, expected: 3`, exactly the dropped-update bug. Restored after.
- `yarn typecheck` 0 errors · `yarn lint` 0 errors (3 pre-existing warnings) · `yarn build` OK

Refs receptron/mulmoclaude#2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)