### PR TITLE
docs: add CLAUDE.md and complete the 2.0.0 changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md — gui-chat-protocol
+
+Layout, scripts, and contributor workflow live in [`AGENTS.md`](./AGENTS.md). This file holds the
+rules specific to what this package *is*: a description of types a host has to be able to honour.
+Everything here was paid for by a bug, so each rule says which one.
+
+## Type design
+
+### NEVER add a type parameter that appears only in the return position
+
+That is a type assertion with nicer syntax. Nothing in the call gives the compiler a way to derive
+`T`, so whatever the caller writes is what it gets:
+
+```ts
+dispatch<T = unknown>(args: object): Promise<T>;   // ✗ T is nowhere in the arguments
+
+const list = await dispatch<Bookmark[]>(args);     // ≡ (await dispatch(args)) as Bookmark[]
+```
+
+The `as` is visible to a reviewer and to `consistent-type-assertions`. The signature above is not,
+and it pushes the assertion into the **host**, which has no way to produce `Promise<T>` from an
+untyped response except `json as T` — the API makes lying a requirement of implementing it. Nothing
+breaks at runtime, which is what makes it dangerous: only *what the compiler believes* changes, so
+the program dies later, far from the cause.
+
+**Instead, take a reader**, so `T` is *inferred from evidence* rather than declared:
+
+```ts
+dispatch(args: object): Promise<unknown>;                             // ✓ no reader → unknown
+dispatch<T>(args: object, parse: (raw: unknown) => T): Promise<T>;    // ✓ T comes from parse
+```
+
+The test: if a type parameter appears in an argument position it is inferred and cannot lie
+(`publish<T>(name, payload: T)` was *useless*, not unsound — it was deleted, not fixed). If it
+appears only in the output, it is the caller's unverified word. See
+[`spec/PLUGIN_RUNTIME.md` → "Why these take a reader"](./spec/PLUGIN_RUNTIME.md#why-these-take-a-reader).
+(#30, 2.0.0. `useRuntime<E>()` is the known remaining instance — #31.)
+
+### A reader that can be passed as something else is a footgun
+
+`subscribe` takes `{ parse }`, not a bare `parse` argument, because **a `void` return type accepts
+any return value** — so every unary function satisfies `(payload: unknown) => void`, and
+`subscribe(name, parse)` with the handler forgotten compiled, registered the validator *as* the
+handler, and discarded every frame with no error at compile time or run time. An object is not
+callable. When adding an overload where two adjacent parameters are both functions, check that
+omitting one is a type error. (#32)
+
+### Say what a throwing reader means
+
+`parse: (raw) => MySchema.parse(raw)` is the idiom this package documents, and Zod's `parse`
+**throws**. Whatever a reader is attached to must specify what a throw does: `dispatch` rejects the
+promise; `subscribe` drops that frame and keeps delivering, because otherwise one malformed frame
+takes down a shared channel and every other subscriber on it. (#32)
+
+## Changing a public signature
+
+`yarn typecheck` covers `src/**` and `test/types/**`. A signature change needs **both** fixtures —
+neither is sufficient alone:
+
+- `test/types/fakeHostRuntime.ts` — a reference host implementation that must compile with **zero
+  type assertions**. Proves a host can satisfy the interface. Copy its overload-declaration +
+  rest-tuple-union shape when implementing one.
+- `test/types/pinnedSignatures.ts` — exact-type pins (`IsExact`). Proves the shape is what we say.
+
+The second exists because the first does not catch a revert: **TypeScript relates an overloaded
+source leniently**, so the reference host satisfies the *old* `dispatch<T = unknown>(args)` exactly
+as happily as the new pair. Reverting the signature left typecheck green until the pins existed.
+
+MUST mutation-test a new pin: break the thing it pins, confirm typecheck goes red, restore. A pin
+that cannot fail is worse than no pin, because it reads as coverage.
+
+## Exceptions
+
+NEVER use an inline `// eslint-disable`. `consistent-type-assertions` is `assertionStyle: "never"`;
+exceptions live in `eslint.config.mjs` as one entry with one reason, and a link to the issue that
+would let the entry be deleted. There are three today, each carrying its rationale.
+
+## Breaking changes
+
+State every route by which callers lose a type, not just the obvious one. For 2.0.0 there were
+three, and only the first has a type argument to grep for:
+
+```ts
+dispatch<Bookmark[]>(args);                      // explicit type argument
+subscribe("changed", (p: Bookmark[]) => { … });  // inferred from the handler annotation
+const list: Bookmark[] = await dispatch(args);   // inferred from the assignment target
+```
+
+Verify migration claims against the built `dist/*.d.ts`, not `src/` — that is what consumers
+actually resolve.

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -51,6 +51,10 @@
 
   Two pre-existing assertions in `src/vue.ts` (`useRuntime<E>()`, `pickMessages<M>()`) are the same unsound-generic family and are excluded via a documented allowlist entry rather than an inline disable — tracked in [#31](https://github.com/receptron/gui-chat-protocol/issues/31), since fixing them changes an API plugins call directly.
 
+- **Dead-code and duplication scanners** ([#29](https://github.com/receptron/gui-chat-protocol/pull/29)). Two report-only static-analysis jobs, neither of which gates CI: **knip** (`knip.jsonc`, every rule `warn` or `off`) writes unused-file / unused-export / unused-dependency findings to the job summary, and **jscpd** v5.0.12 (pinned, SHA256-verified binary, no `--threshold`) uploads copy/paste findings as SARIF to code scanning. knip reports zero findings. jscpd's single clone — the logger shape mirrored between `PluginRuntime.log` and `BrowserPluginRuntime.log` — is left as-is deliberately: extracting a shared `PluginLogger` type would add an exported type to the published `.d.ts` surface, and the mirror is intentional (the `vue.ts` field is commented "Same shape as the server-side logger").
+
+- **Dependency maintenance** ([#28](https://github.com/receptron/gui-chat-protocol/pull/28)). devDependencies only, all minor/patch: `@types/react` 19.2.17→19.2.18, `eslint` 10.3.0→10.8.0, `globals` 17.4.0→17.8.0, `react` 19.2.7→19.2.8, `vite` 8.1.5→8.2.0. `yarn audit` reports 0 vulnerabilities across 209 packages; `yarn-deduplicate` found nothing to collapse. No source or config changes were needed. **TypeScript deliberately held at `^6.0.3`** — TS 7 (native/tsgo) breaks `ts-node@10`, and `typescript-eslint@8` supports only `typescript <6.1.0`, so moving to TS 7 is its own migration.
+
 📦 npm: [`gui-chat-protocol@2.0.0`](https://www.npmjs.com/package/gui-chat-protocol/v/2.0.0)
 
 ## 1.2.0 — 2026-07-24


### PR DESCRIPTION
## Summary

Post-2.0.0 documentation. Two files, no code.

- **`docs/ChangeLog.md`** — the 2.0.0 entry covered only #32, while the [GitHub release](https://github.com/receptron/gui-chat-protocol/releases/tag/v2.0.0) covers every PR since `v1.2.0`. Added #29 (knip + jscpd scanners) and #28 (dependency maintenance) so the two agree.
- **`CLAUDE.md`** (new) — the rules this release was paid for, each carrying the issue that bought it. Layout, scripts, and contributor workflow stay in `AGENTS.md`; this file deliberately does not duplicate them.

## Items to Confirm / Review

1. **`CLAUDE.md` alongside `AGENTS.md`** — this repo had only `AGENTS.md`. Rather than fold type-design rules into it, `CLAUDE.md` holds the *rules* (what must not happen, and why) and links to `AGENTS.md` for the *how*. Confirm you want two files rather than one.
2. **Scope of what got written down.** Four rules, each traceable to a concrete bug in this release rather than to taste:
   - never add a type parameter that appears only in the return position (it is `as` in disguise) — #30
   - a reader that can be passed as something else is a footgun (`{ parse }` over bare `parse`, because a `void` return type accepts any return value) — #32
   - whatever a reader is attached to must specify what a *throw* means — #32
   - a signature change needs both type fixtures, because an overloaded source satisfies the old signature too, and a new pin must be mutation-tested — #32
3. **Migration claims are verified against `dist/*.d.ts`, not `src/`** is recorded as a rule. That is what caught the incorrect three-routes note in the 2.0.0 PR.

## User Prompt

> publish, このレポの claude.md への追記, ブログ, 全部やろう

This PR is the middle item. `gui-chat-protocol@2.0.0` is published and the release is cut; the blog article is separate.

## Verification

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn test` (28 pass), `yarn build` — all green.

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in gui-chat-protocol
